### PR TITLE
Included the treetagger model directly and removed emf

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,6 @@ Determines the separator which should be artificially added after a token, when 
 >
 > The separator sequence, must be surrounded by double quotes. To shut of the adding of a separator, just this property value to "".
 
-<<<<<<< HEAD
 ### treetagger.input.prefixElementToAttributes
 
 Choose whether to prefix the element name to all span annotation attributes. For example, if set to true, then for a span <date when="2016">, the 'when' annotation becomes date_when (the default separator is `_` and can be configured).
@@ -222,7 +221,6 @@ Choose whether to prefix the element name to all span annotation attributes. For
 
 The string to use to separate element and attribute name when using the prefixElementToAttributes option. By default this is '_' ,so that for a span <date when="2016">, the 'when' annotation becomes date_when="2016".
 
-=======
 #### treetagger.input.column[1-9][0-9]*
 
 This property allows to import more than the three default columns: token, part-of-speech and lemma. You can determine an unbound number of columns and name each column. Imagine the following file, where 1st column is the token itself, the second is the part-of-speech annotation, the third is the lemma annotation, the fourth stands for claws and the third for token function:
@@ -245,7 +243,6 @@ The corresponding customization properties would look like this:
 <property key="treetagger.input.column3">claws</property>
 <property key="treetagger.input.column4">tok_func</property>
 ```
->>>>>>> refs/heads/develop
 
 #<a name="details_ex"/>TreetaggerExporter
 Mapping to TreeTagger format

--- a/README.md
+++ b/README.md
@@ -196,6 +196,19 @@ The following table contains an overview of all usable properties to customize t
 <td align="left">optional</td>
 <td align="left">&quot; &quot;</td>
 </tr>
+<tr class="odd">
+<td align="left">treetagger.input.prefixElementToAttributes</td>
+<td align="left">Boolean</td>
+<td align="left">optional</td>
+<td align="left">false</td>
+</tr>
+<tr class="even">
+<td align="left">treetagger.input.prefixElementSeparator</td>
+<td align="left">String</td>
+<td align="left">optional</td>
+<td align="left">_</td>
+</tr>
+
 </tbody>
 </table>
 
@@ -218,6 +231,14 @@ Determines the separator which should be artificially added after a token, when 
 > **Note**
 >
 > The separator sequence, must be surrounded by double quotes. To shut of the adding of a separator, just this property value to "".
+
+### treetagger.input.prefixElementToAttributes
+
+Choose whether to prefix the element name to all span annotation attributes. For example, if set to true, then for a span <date when="2016">, the 'when' annotation becomes date_when (the default separator is `_` and can be configured).
+
+### treetagger.input.prefixElementSeparator
+
+The string to use to separate element and attribute name when using the prefixElementToAttributes option. By default this is '_' ,so that for a span <date when="2016">, the 'when' annotation becomes date_when="2016".
 
 
 #<a name="details_ex"/>TreetaggerExporter

--- a/pom.xml
+++ b/pom.xml
@@ -26,11 +26,4 @@
 		<url>https://github.com/korpling/pepperModules-TreetaggerModules</url>
 	  <tag>HEAD</tag>
   </scm>
-	<dependencies>
-		<dependency>
-			<groupId>org.corpus-tools</groupId>
-			<artifactId>treetagger-emf-api</artifactId>
-			<version>[1.3.0,2.0.0)</version>
-		</dependency>
-	</dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	</parent>
 	<artifactId>pepperModules-TreetaggerModules</artifactId>
 	<name>${project.groupId}.${project.artifactId}</name>
-	<version>1.2.9-SNAPSHOT</version>
+	<version>2.0.0-SNAPSHOT</version>
 	<packaging>bundle</packaging>
 	<description>This project provides a Pepper importer and exporter for Treetagger data.</description>
 	<url>https://github.com/korpling/pepperModules-TreetaggerModules</url>

--- a/src/main/java/org/corpus_tools/peppermodules/treetagger/TreetaggerImporter.java
+++ b/src/main/java/org/corpus_tools/peppermodules/treetagger/TreetaggerImporter.java
@@ -17,25 +17,19 @@
  */
 package org.corpus_tools.peppermodules.treetagger;
 
-import java.io.IOException;
+import java.util.List;
 
 import org.corpus_tools.pepper.common.PepperConfiguration;
 import org.corpus_tools.pepper.impl.PepperImporterImpl;
 import org.corpus_tools.pepper.modules.PepperImporter;
 import org.corpus_tools.pepper.modules.PepperMapper;
-import org.corpus_tools.pepper.modules.exceptions.PepperModuleException;
 import org.corpus_tools.peppermodules.treetagger.mapper.Treetagger2SaltMapper;
+import org.corpus_tools.peppermodules.treetagger.model.Document;
+import org.corpus_tools.peppermodules.treetagger.model.resources.TabReader;
 import org.corpus_tools.salt.common.SDocument;
 import org.corpus_tools.salt.graph.Identifier;
 import org.eclipse.emf.common.util.URI;
-import org.eclipse.emf.ecore.resource.Resource;
-import org.eclipse.emf.ecore.resource.ResourceSet;
-import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
-import org.eclipse.emf.ecore.xmi.impl.XMIResourceFactoryImpl;
 import org.osgi.service.component.annotations.Component;
-
-import de.hu_berlin.german.korpling.saltnpepper.misc.treetagger.Document;
-import de.hu_berlin.german.korpling.saltnpepper.misc.treetagger.resources.TabResourceFactory;
 
 /**
  * This class imports data from Treetagger format to Salt
@@ -68,8 +62,8 @@ public class TreetaggerImporter extends PepperImporterImpl implements PepperImpo
 	}
 
 	/**
-	 * Creates a mapper of type {@link PAULA2SaltMapper}. {@inheritDoc
-	 * PepperModule#createPepperMapper(Identifier)}
+	 * Creates a mapper of type {@link PAULA2SaltMapper}.
+	 * {@inheritDoc PepperModule#createPepperMapper(Identifier)}
 	 */
 	@Override
 	public PepperMapper createPepperMapper(Identifier sElementId) {
@@ -91,32 +85,47 @@ public class TreetaggerImporter extends PepperImporterImpl implements PepperImpo
 	private Document loadFromFile(URI uri) {
 		Document retVal = null;
 		if (uri != null) {
-			// create resource set and resource
-			ResourceSet resourceSet = new ResourceSetImpl();
 
-			// Register XML resource factory
-			resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put("treetagger", new XMIResourceFactoryImpl());
-			TabResourceFactory tabResourceFactory = new TabResourceFactory();
-			resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put("tab", tabResourceFactory);
-			resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put("tt", tabResourceFactory);
-			resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put("txt", tabResourceFactory);
-			Resource resource = null;
-			try {
-				// load resource
-				resource = resourceSet.createResource(uri);
+			TabReader reader = new TabReader();
+			List<Document> documents = reader.load(uri, getProperties().getProperties());
 
-				if (resource == null) {
-					throw new PepperModuleException(this, "Cannot load The resource is null.");
-				}
-				resource.load(getProperties().getProperties());
-			} catch (IOException e) {
-				throw new PepperModuleException(this, "Cannot load resource '" + uri + "'.", e);
-			} catch (NullPointerException e) {
-				throw new PepperModuleException(this, "Cannot load resource '" + uri + "'.", e);
+			if (!documents.isEmpty()) {
+				retVal = documents.get(0);
 			}
-			if (resource.getContents().size() > 0) {
-				retVal = (Document) resource.getContents().get(0);
-			}
+
+			// // create resource set and resource
+			// ResourceSet resourceSet = new ResourceSetImpl();
+			//
+			// // Register XML resource factory
+			// resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put("treetagger",
+			// new XMIResourceFactoryImpl());
+			// TabResourceFactory tabResourceFactory = new TabResourceFactory();
+			// resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put("tab",
+			// tabResourceFactory);
+			// resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put("tt",
+			// tabResourceFactory);
+			// resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put("txt",
+			// tabResourceFactory);
+			// Resource resource = null;
+			// try {
+			// // load resource
+			// resource = resourceSet.createResource(uri);
+			//
+			// if (resource == null) {
+			// throw new PepperModuleException(this, "Cannot load The resource
+			// is null.");
+			// }
+			// resource.load(getProperties().getProperties());
+			// } catch (IOException e) {
+			// throw new PepperModuleException(this, "Cannot load resource '" +
+			// uri + "'.", e);
+			// } catch (NullPointerException e) {
+			// throw new PepperModuleException(this, "Cannot load resource '" +
+			// uri + "'.", e);
+			// }
+			// if (resource.getContents().size() > 0) {
+			// retVal = (Document) resource.getContents().get(0);
+			// }
 		}
 		return (retVal);
 	}

--- a/src/main/java/org/corpus_tools/peppermodules/treetagger/TreetaggerImporterProperties.java
+++ b/src/main/java/org/corpus_tools/peppermodules/treetagger/TreetaggerImporterProperties.java
@@ -22,6 +22,8 @@ import org.corpus_tools.pepper.modules.PepperModuleProperty;
 import org.corpus_tools.salt.common.SToken;
 
 public class TreetaggerImporterProperties extends PepperModuleProperties {
+	private static final long serialVersionUID = -7528434389946019271L;
+
 	public static final String PREFIX = "treetagger.input.";
 
 	public static final String PROP_ANNOTATE_UNANNOTATED_SPANS = PREFIX + "annotateUnannotatedSpans";
@@ -35,17 +37,24 @@ public class TreetaggerImporterProperties extends PepperModuleProperties {
 	/**
 	 * Name of property to determine the separator which should be artificially
 	 * added after a token, when mapping treetagger token to STextualDS in Salt.
-	 * The default separator is a whitespace given by the character sequence
-	 * " ". Note, the separator sequence, must be surrounded by double quotes.
-	 * To shut of the adding of a separator, just this property value to "".
+	 * The default separator is a whitespace given by the character sequence "
+	 * ". Note, the separator sequence, must be surrounded by double quotes. To
+	 * shut of the adding of a separator, just this property value to "".
 	 **/
 	public static final String PROP_SEPARATOR_AFTER_TOKEN = PREFIX + "separatorAfterToken";
 
 	public TreetaggerImporterProperties() {
-		this.addProperty(new PepperModuleProperty<Boolean>(PROP_ANNOTATE_UNANNOTATED_SPANS, Boolean.class, "If set true, this switch will cause the module to annotate all spans without attributes with their name as attribute and value.", false, false));
-		this.addProperty(new PepperModuleProperty<Boolean>(PROP_ANNOTATE_ALL_SPANS_WITH_NAME, Boolean.class, "If set true, this switch will cause the module to annotate all spans with their name as attribute and value.", false, false));
-		this.addProperty(new PepperModuleProperty<String>(PROP_META_TAG, String.class, "States the meta tag used to mark the TreeTagger document in the input file(s).", "meta", false));
-		this.addProperty(new PepperModuleProperty<String>(PROP_SEPARATOR_AFTER_TOKEN, String.class, "Determines the separator which should be artificially added after a token, when mapping treetagger token to STextualDS in Salt. The default separator is a whitespace given by the character sequence \" \". Note, the separator sequence, must be surrunded by double quotes. To shut of the adding of a separator, just this property value to \"\"", " ", false));
+		this.addProperty(new PepperModuleProperty<Boolean>(PROP_ANNOTATE_UNANNOTATED_SPANS, Boolean.class,
+				"If set true, this switch will cause the module to annotate all spans without attributes with their name as attribute and value.",
+				false, false));
+		this.addProperty(new PepperModuleProperty<Boolean>(PROP_ANNOTATE_ALL_SPANS_WITH_NAME, Boolean.class,
+				"If set true, this switch will cause the module to annotate all spans with their name as attribute and value.",
+				false, false));
+		this.addProperty(new PepperModuleProperty<String>(PROP_META_TAG, String.class,
+				"States the meta tag used to mark the TreeTagger document in the input file(s).", "meta", false));
+		this.addProperty(new PepperModuleProperty<String>(PROP_SEPARATOR_AFTER_TOKEN, String.class,
+				"Determines the separator which should be artificially added after a token, when mapping treetagger token to STextualDS in Salt. The default separator is a whitespace given by the character sequence \" \". Note, the separator sequence, must be surrunded by double quotes. To shut of the adding of a separator, just this property value to \"\"",
+				" ", false));
 	}
 
 	public Boolean getAnnotateUnannotatedSpans() {

--- a/src/main/java/org/corpus_tools/peppermodules/treetagger/TreetaggerImporterProperties.java
+++ b/src/main/java/org/corpus_tools/peppermodules/treetagger/TreetaggerImporterProperties.java
@@ -43,6 +43,13 @@ public class TreetaggerImporterProperties extends PepperModuleProperties {
 	 **/
 	public static final String PROP_SEPARATOR_AFTER_TOKEN = PREFIX + "separatorAfterToken";
 
+        /**
+        * Set to true to add the element name as a prefix to all span element attribute annotations.
+        **/
+        public static final String PROP_PREFIX_SPAN_ANNOS_WITH_ELEMENT = PREFIX + "prefixElementToAttributes";
+        public static final String PROP_PREFIX_ELEMENT_SEPARATOR = PREFIX + "prefixElementSeparator";
+
+        
 	public TreetaggerImporterProperties() {
 		this.addProperty(new PepperModuleProperty<Boolean>(PROP_ANNOTATE_UNANNOTATED_SPANS, Boolean.class,
 				"If set true, this switch will cause the module to annotate all spans without attributes with their name as attribute and value.",
@@ -55,6 +62,8 @@ public class TreetaggerImporterProperties extends PepperModuleProperties {
 		this.addProperty(new PepperModuleProperty<String>(PROP_SEPARATOR_AFTER_TOKEN, String.class,
 				"Determines the separator which should be artificially added after a token, when mapping treetagger token to STextualDS in Salt. The default separator is a whitespace given by the character sequence \" \". Note, the separator sequence, must be surrunded by double quotes. To shut of the adding of a separator, just this property value to \"\"",
 				" ", false));
+		this.addProperty(new PepperModuleProperty<Boolean>(PROP_PREFIX_SPAN_ANNOS_WITH_ELEMENT, Boolean.class, "Set to true to add the element name as a prefix to all span element attribute annotations.", false, false));
+		this.addProperty(new PepperModuleProperty<String>(PROP_PREFIX_ELEMENT_SEPARATOR, String.class, "Separator to use when prefixing span attribute annotations with element name.", "_", false));
 	}
 
 	public Boolean getAnnotateUnannotatedSpans() {
@@ -65,6 +74,15 @@ public class TreetaggerImporterProperties extends PepperModuleProperties {
 		return ((Boolean) this.getProperty(PROP_ANNOTATE_ALL_SPANS_WITH_NAME).getValue());
 	}
 
+        public Boolean getPrefixSpanAnnotation() {
+        return ((Boolean) this.getProperty(PROP_PREFIX_SPAN_ANNOS_WITH_ELEMENT).getValue());
+	}
+
+        public String getPrefixSpanSeparator(){
+                return (String) this.getProperty(PROP_PREFIX_ELEMENT_SEPARATOR).getValue();
+        }
+
+        
 	/**
 	 * Returns the separator to be used to separate the text covered by
 	 * {@link SToken}.

--- a/src/main/java/org/corpus_tools/peppermodules/treetagger/mapper/Treetagger2SaltMapper.java
+++ b/src/main/java/org/corpus_tools/peppermodules/treetagger/mapper/Treetagger2SaltMapper.java
@@ -24,6 +24,12 @@ import org.corpus_tools.pepper.common.DOCUMENT_STATUS;
 import org.corpus_tools.pepper.impl.PepperMapperImpl;
 import org.corpus_tools.pepper.modules.PepperMapper;
 import org.corpus_tools.peppermodules.treetagger.TreetaggerImporterProperties;
+import org.corpus_tools.peppermodules.treetagger.model.Annotation;
+import org.corpus_tools.peppermodules.treetagger.model.Document;
+import org.corpus_tools.peppermodules.treetagger.model.LemmaAnnotation;
+import org.corpus_tools.peppermodules.treetagger.model.POSAnnotation;
+import org.corpus_tools.peppermodules.treetagger.model.Span;
+import org.corpus_tools.peppermodules.treetagger.model.Token;
 import org.corpus_tools.salt.SaltFactory;
 import org.corpus_tools.salt.common.SDocument;
 import org.corpus_tools.salt.common.SSpan;
@@ -32,13 +38,6 @@ import org.corpus_tools.salt.common.STextualDS;
 import org.corpus_tools.salt.common.STextualRelation;
 import org.corpus_tools.salt.common.SToken;
 import org.corpus_tools.salt.core.SAnnotation;
-
-import de.hu_berlin.german.korpling.saltnpepper.misc.treetagger.Annotation;
-import de.hu_berlin.german.korpling.saltnpepper.misc.treetagger.Document;
-import de.hu_berlin.german.korpling.saltnpepper.misc.treetagger.LemmaAnnotation;
-import de.hu_berlin.german.korpling.saltnpepper.misc.treetagger.POSAnnotation;
-import de.hu_berlin.german.korpling.saltnpepper.misc.treetagger.Span;
-import de.hu_berlin.german.korpling.saltnpepper.misc.treetagger.Token;
 
 /**
  * This class is for mapping Treetagger to Salt

--- a/src/main/java/org/corpus_tools/peppermodules/treetagger/mapper/Treetagger2SaltMapper.java
+++ b/src/main/java/org/corpus_tools/peppermodules/treetagger/mapper/Treetagger2SaltMapper.java
@@ -101,6 +101,8 @@ public class Treetagger2SaltMapper extends PepperMapperImpl implements PepperMap
 		boolean annotateUnannotatedSpans = this.getProps().getAnnotateUnannotatedSpans();
 
 		boolean annotateAllSpansWithSpanName = this.getProps().getAnnotateAllSpansWithName();
+                boolean prefixSpanAnnotation = this.getProps().getPrefixSpanAnnotation();
+                String prefixSpanSeparator = this.getProps().getPrefixSpanSeparator();
 
 		// creating and adding STextualDS
 		STextualDS sText = SaltFactory.createSTextualDS();
@@ -143,6 +145,9 @@ public class Treetagger2SaltMapper extends PepperMapperImpl implements PepperMap
 					}
 					for (int j = 0; j < tAnnotations.size(); j++) {
 						SAnnotation anno = this.createAnnotation(tSpan.getAnnotations().get(j));
+                                                if (prefixSpanAnnotation){
+                                                    anno.setName(tSpan.getName() + prefixSpanSeparator + anno.getName());
+                                                }
 						sSpan.addAnnotation(anno);
 					}
 				} else {

--- a/src/main/java/org/corpus_tools/peppermodules/treetagger/model/AnnotatableElement.java
+++ b/src/main/java/org/corpus_tools/peppermodules/treetagger/model/AnnotatableElement.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2009 Humboldt-Universität zu Berlin, INRIA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+package org.corpus_tools.peppermodules.treetagger.model;
+
+import java.util.List;
+
+public interface AnnotatableElement {
+	List<Annotation> getAnnotations();
+}

--- a/src/main/java/org/corpus_tools/peppermodules/treetagger/model/Annotation.java
+++ b/src/main/java/org/corpus_tools/peppermodules/treetagger/model/Annotation.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2009 Humboldt-Universität zu Berlin, INRIA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+package org.corpus_tools.peppermodules.treetagger.model;
+
+public interface Annotation {
+	String getName();
+
+	void setName(String value);
+
+	String getValue();
+
+	void setValue(String value);
+
+	AnnotatableElement getAnnotatableElement();
+
+	void setAnnotatableElement(AnnotatableElement value);
+
+} // Annotation

--- a/src/main/java/org/corpus_tools/peppermodules/treetagger/model/AnyAnnotation.java
+++ b/src/main/java/org/corpus_tools/peppermodules/treetagger/model/AnyAnnotation.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2009 Humboldt-Universität zu Berlin, INRIA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+package org.corpus_tools.peppermodules.treetagger.model;
+
+public interface AnyAnnotation extends Annotation {
+
+} // AnyAnnotation

--- a/src/main/java/org/corpus_tools/peppermodules/treetagger/model/Document.java
+++ b/src/main/java/org/corpus_tools/peppermodules/treetagger/model/Document.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2009 Humboldt-Universität zu Berlin, INRIA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+package org.corpus_tools.peppermodules.treetagger.model;
+
+import java.util.List;
+
+public interface Document extends AnnotatableElement {
+	String getName();
+
+	void setName(String value);
+
+	List<Token> getTokens();
+
+}

--- a/src/main/java/org/corpus_tools/peppermodules/treetagger/model/LemmaAnnotation.java
+++ b/src/main/java/org/corpus_tools/peppermodules/treetagger/model/LemmaAnnotation.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2009 Humboldt-Universität zu Berlin, INRIA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+package org.corpus_tools.peppermodules.treetagger.model;
+
+public interface LemmaAnnotation extends Annotation {
+} // LemmaAnnotation

--- a/src/main/java/org/corpus_tools/peppermodules/treetagger/model/POSAnnotation.java
+++ b/src/main/java/org/corpus_tools/peppermodules/treetagger/model/POSAnnotation.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2009 Humboldt-Universität zu Berlin, INRIA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+package org.corpus_tools.peppermodules.treetagger.model;
+
+public interface POSAnnotation extends Annotation {
+} // POSAnnotation

--- a/src/main/java/org/corpus_tools/peppermodules/treetagger/model/Span.java
+++ b/src/main/java/org/corpus_tools/peppermodules/treetagger/model/Span.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2009 Humboldt-Universität zu Berlin, INRIA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+package org.corpus_tools.peppermodules.treetagger.model;
+
+import java.util.List;
+
+public interface Span extends AnnotatableElement {
+	String getName();
+
+	void setName(String value);
+
+	List<Token> getTokens();
+
+} // Span

--- a/src/main/java/org/corpus_tools/peppermodules/treetagger/model/Token.java
+++ b/src/main/java/org/corpus_tools/peppermodules/treetagger/model/Token.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2009 Humboldt-Universität zu Berlin, INRIA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+package org.corpus_tools.peppermodules.treetagger.model;
+
+import java.util.List;
+
+public interface Token extends AnnotatableElement {
+	String getText();
+
+	void setText(String value);
+
+	POSAnnotation getPosAnnotation();
+
+	void setPosAnnotation(POSAnnotation value);
+
+	LemmaAnnotation getLemmaAnnotation();
+
+	void setLemmaAnnotation(LemmaAnnotation value);
+
+	Document getDocument();
+
+	void setDocument(Document value);
+
+	List<Span> getSpans();
+}

--- a/src/main/java/org/corpus_tools/peppermodules/treetagger/model/TreetaggerFactory.java
+++ b/src/main/java/org/corpus_tools/peppermodules/treetagger/model/TreetaggerFactory.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2009 Humboldt-Universität zu Berlin, INRIA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+package org.corpus_tools.peppermodules.treetagger.model;
+
+public interface TreetaggerFactory {
+	TreetaggerFactory eINSTANCE = org.corpus_tools.peppermodules.treetagger.model.impl.TreetaggerFactoryImpl.init();
+
+	Document createDocument();
+
+	Token createToken();
+
+	Annotation createAnnotation();
+
+	POSAnnotation createPOSAnnotation();
+
+	LemmaAnnotation createLemmaAnnotation();
+
+	AnyAnnotation createAnyAnnotation();
+
+	Span createSpan();
+
+}

--- a/src/main/java/org/corpus_tools/peppermodules/treetagger/model/impl/AnnotatableElementImpl.java
+++ b/src/main/java/org/corpus_tools/peppermodules/treetagger/model/impl/AnnotatableElementImpl.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2009 Humboldt-Universität zu Berlin, INRIA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+package org.corpus_tools.peppermodules.treetagger.model.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.corpus_tools.peppermodules.treetagger.model.AnnotatableElement;
+import org.corpus_tools.peppermodules.treetagger.model.Annotation;
+
+public abstract class AnnotatableElementImpl implements AnnotatableElement {
+	protected List<Annotation> annotations = new ArrayList<>();
+
+	protected AnnotatableElementImpl() {
+		super();
+	}
+
+	@Override
+	public List<Annotation> getAnnotations() {
+		return annotations;
+	}
+
+	/**
+	 * Checks this and given object for equality. Conditions for equality:
+	 * Object must be instance of AnnotatableElement, getAnnotations().size()
+	 * must be equal and all Annotations must correspond.
+	 * 
+	 * @param obj
+	 *            An object
+	 * @return true or false
+	 */
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (!(obj instanceof AnnotatableElement)) {
+			return false;
+		}
+
+		AnnotatableElement annotatableElement = (AnnotatableElement) obj;
+
+		// ##### compare annotations (order not relevant) #####
+		if (this.getAnnotations().size() != annotatableElement.getAnnotations().size()) {
+			return false;
+		}
+		// iteration via counter (not iterator) -> threadsave!
+		for (int i = 0; i < this.getAnnotations().size(); i++) {
+
+			boolean equalExists = false;
+			for (int j = 0; (j < annotatableElement.getAnnotations().size()) && !equalExists; j++) {
+				equalExists = (annotatableElement.getAnnotations().get(j).equals(this.getAnnotations().get(i)));
+			}
+			if (!equalExists) {
+				return false;
+			}
+		}
+
+		// okay fine
+		return true;
+	}
+
+} // AnnotatableElementImpl

--- a/src/main/java/org/corpus_tools/peppermodules/treetagger/model/impl/AnnotationImpl.java
+++ b/src/main/java/org/corpus_tools/peppermodules/treetagger/model/impl/AnnotationImpl.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright 2009 Humboldt-Universität zu Berlin, INRIA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+package org.corpus_tools.peppermodules.treetagger.model.impl;
+
+import org.corpus_tools.peppermodules.treetagger.model.AnnotatableElement;
+import org.corpus_tools.peppermodules.treetagger.model.Annotation;
+
+public class AnnotationImpl implements Annotation {
+	protected String name = null;
+	protected String value = null;
+	protected AnnotatableElement annotatableElement;
+
+	protected AnnotationImpl() {
+		super();
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public void setName(String newName) {
+		name = newName;
+	}
+
+	@Override
+	public String getValue() {
+		return value;
+	}
+
+	@Override
+	public void setValue(String newValue) {
+		value = newValue;
+	}
+
+	@Override
+	public AnnotatableElement getAnnotatableElement() {
+		return annotatableElement;
+	}
+
+	@Override
+	public void setAnnotatableElement(AnnotatableElement newAnnotatableElement) {
+		annotatableElement = newAnnotatableElement;
+	}
+
+	/**
+	 * TODO: describe
+	 */
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (!(obj instanceof Annotation)) {
+			return false;
+		}
+		Annotation anno = (Annotation) obj;
+
+		// ##### compare name #####
+		if (((this.getName() != null) && (!(this.getName().equals(anno.getName()))))
+				|| ((anno.getName() != null) && (!(anno.getName().equals(this.getName()))))) {
+			return false;
+		}
+
+		// ##### compare value #####
+		if (((this.getValue() != null) && (!(this.getValue().equals(anno.getValue()))))
+				|| ((anno.getValue() != null) && (!(anno.getValue().equals(this.getValue()))))) {
+			return false;
+		}
+
+		// okay fine
+		return true;
+	}
+
+} // AnnotationImpl

--- a/src/main/java/org/corpus_tools/peppermodules/treetagger/model/impl/AnyAnnotationImpl.java
+++ b/src/main/java/org/corpus_tools/peppermodules/treetagger/model/impl/AnyAnnotationImpl.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2009 Humboldt-Universität zu Berlin, INRIA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+package org.corpus_tools.peppermodules.treetagger.model.impl;
+
+import org.corpus_tools.peppermodules.treetagger.model.AnyAnnotation;
+
+public class AnyAnnotationImpl extends AnnotationImpl implements AnyAnnotation {
+	protected AnyAnnotationImpl() {
+		super();
+	}
+
+	public String getAnyName() {
+		return (super.getName());
+	}
+
+	public void setAnyName(String newAnyName) {
+		super.name = newAnyName;
+	}
+
+}

--- a/src/main/java/org/corpus_tools/peppermodules/treetagger/model/impl/DocumentImpl.java
+++ b/src/main/java/org/corpus_tools/peppermodules/treetagger/model/impl/DocumentImpl.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright 2009 Humboldt-Universität zu Berlin, INRIA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+package org.corpus_tools.peppermodules.treetagger.model.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.corpus_tools.peppermodules.treetagger.model.Document;
+import org.corpus_tools.peppermodules.treetagger.model.Token;
+
+public class DocumentImpl extends AnnotatableElementImpl implements Document {
+
+	protected String name = null;
+
+	protected List<Token> tokens = new ArrayList<>();
+
+	protected DocumentImpl() {
+		super();
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public void setName(String newName) {
+		name = newName;
+	}
+
+	@Override
+	public List<Token> getTokens() {
+		return tokens;
+	}
+
+	/**
+	 * Checks this and given object for equality. Conditions for equality:
+	 * Object must be instance of Document, getTokens().size() must be equal,
+	 * all Tokens must be equal and all annotations must correspond.
+	 * 
+	 * @param obj
+	 *            An object
+	 * @return true or false
+	 */
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+
+		if (!(obj instanceof Document)) {
+			return false;
+		}
+
+		Document doc = (Document) obj;
+
+		// this can only be used if documents are really identical (including
+		// names), but this method only has to check for equality of contents
+		// //##### compare names #####
+		// if
+		// (((this.getName()!=null)&&(!(this.getName().equals(doc.getName()))))
+		// ||((doc.getName()!=null)&&(!(doc.getName().equals(this.getName())))))
+		// {
+		// return false;
+		// }
+
+		// ##### compare tokens (mind order) #####
+		if (this.getTokens().size() != doc.getTokens().size()) {
+			return false;
+		}
+
+		// iteration via counter (not iterator) -> threadsave!
+		for (int i = 0; i < this.getTokens().size(); i++) {
+			if (!this.getTokens().get(i).equals(doc.getTokens().get(i))) {
+				return false;
+			}
+		}
+
+		// okay fine, check super to compare Annotations
+		return super.equals(obj);
+	}
+
+} // DocumentImpl

--- a/src/main/java/org/corpus_tools/peppermodules/treetagger/model/impl/LemmaAnnotationImpl.java
+++ b/src/main/java/org/corpus_tools/peppermodules/treetagger/model/impl/LemmaAnnotationImpl.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2009 Humboldt-Universität zu Berlin, INRIA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+package org.corpus_tools.peppermodules.treetagger.model.impl;
+
+import org.corpus_tools.peppermodules.treetagger.model.LemmaAnnotation;
+
+public class LemmaAnnotationImpl extends AnnotationImpl implements LemmaAnnotation {
+	protected LemmaAnnotationImpl() {
+		super();
+		super.name = "lemma";
+	}
+
+	/**
+	 * Does not set the name - name will always be set to "lemma"
+	 */
+	@Override
+	public void setName(String newValue) {
+		super.setName("lemma");
+	}
+
+}

--- a/src/main/java/org/corpus_tools/peppermodules/treetagger/model/impl/POSAnnotationImpl.java
+++ b/src/main/java/org/corpus_tools/peppermodules/treetagger/model/impl/POSAnnotationImpl.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2009 Humboldt-Universität zu Berlin, INRIA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+package org.corpus_tools.peppermodules.treetagger.model.impl;
+
+import org.corpus_tools.peppermodules.treetagger.model.POSAnnotation;
+
+public class POSAnnotationImpl extends AnnotationImpl implements POSAnnotation {
+	protected POSAnnotationImpl() {
+		super();
+		super.name = "pos";
+	}
+
+	/**
+	 * Does not set the name - name will always be set to "pos"
+	 */
+	@Override
+	public void setName(String newValue) {
+		super.setName("pos");
+	}
+
+}

--- a/src/main/java/org/corpus_tools/peppermodules/treetagger/model/impl/SpanImpl.java
+++ b/src/main/java/org/corpus_tools/peppermodules/treetagger/model/impl/SpanImpl.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2009 Humboldt-Universität zu Berlin, INRIA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+package org.corpus_tools.peppermodules.treetagger.model.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.corpus_tools.peppermodules.treetagger.model.Span;
+import org.corpus_tools.peppermodules.treetagger.model.Token;
+
+public class SpanImpl extends AnnotatableElementImpl implements Span {
+	protected String name = null;
+	protected List<Token> tokens = new ArrayList<>();
+
+	protected SpanImpl() {
+		super();
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public void setName(String newName) {
+		name = newName;
+	}
+
+	@Override
+	public List<Token> getTokens() {
+		return tokens;
+	}
+
+	/**
+	 * Checks this and given object for equality. Conditions for equality:
+	 * Object must be instance of Span, have the same name as this,
+	 * getTokens().size() must be equal and annotations must be equal.
+	 * 
+	 * @param obj
+	 *            An object
+	 * @return true or false
+	 */
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+
+		if (!(obj instanceof Span)) {
+			return false;
+		}
+
+		Span span = (Span) obj;
+
+		// ##### compare names #####
+		if (((this.getName() != null) && (!(this.getName().equals(span.getName()))))
+				|| ((span.getName() != null) && (!(span.getName().equals(this.getName()))))) {
+			return false;
+		}
+
+		// ##### compare tokens (mind order) #####
+		if (this.getTokens().size() != span.getTokens().size()) {
+			return false;
+		}
+
+		// this would cause stack overflow, because spans test tokens and tokens
+		// test spans
+		// iteration via counter (not iterator) -> threadsave!
+		// for (int i=0;i<this.getTokens().size();i++) {
+		// if (!this.getTokens().get(i).equals(span.getTokens().get(i))) {
+		// return false;
+		// }
+		// }
+
+		// okay fine, check super to compare Annotations
+		return super.equals(obj);
+	}
+
+} // SpanImpl

--- a/src/main/java/org/corpus_tools/peppermodules/treetagger/model/impl/TokenImpl.java
+++ b/src/main/java/org/corpus_tools/peppermodules/treetagger/model/impl/TokenImpl.java
@@ -1,0 +1,138 @@
+/**
+ * Copyright 2009 Humboldt-Universität zu Berlin, INRIA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+package org.corpus_tools.peppermodules.treetagger.model.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.corpus_tools.peppermodules.treetagger.model.Annotation;
+import org.corpus_tools.peppermodules.treetagger.model.Document;
+import org.corpus_tools.peppermodules.treetagger.model.LemmaAnnotation;
+import org.corpus_tools.peppermodules.treetagger.model.POSAnnotation;
+import org.corpus_tools.peppermodules.treetagger.model.Span;
+import org.corpus_tools.peppermodules.treetagger.model.Token;
+
+public class TokenImpl extends AnnotatableElementImpl implements Token {
+
+	protected String text = null;
+
+	protected List<Span> spans = new ArrayList<>();
+	protected Document document = null;
+
+	protected TokenImpl() {
+		super();
+	}
+
+	@Override
+	public String getText() {
+		return text;
+	}
+
+	@Override
+	public void setText(String newText) {
+		text = newText;
+	}
+
+	@Override
+	public POSAnnotation getPosAnnotation() {
+		POSAnnotation posAnno = null;
+		for (Annotation anno : this.getAnnotations()) {
+			if (anno instanceof POSAnnotation)
+				posAnno = (POSAnnotation) anno;
+		}
+		return (posAnno);
+	}
+
+	@Override
+	public void setPosAnnotation(POSAnnotation newPosAnnotation) {
+		this.getAnnotations().add(newPosAnnotation);
+	}
+
+	@Override
+	public LemmaAnnotation getLemmaAnnotation() {
+		LemmaAnnotation lemmaAnno = null;
+		for (Annotation anno : this.getAnnotations()) {
+			if (anno instanceof LemmaAnnotation)
+				lemmaAnno = (LemmaAnnotation) anno;
+		}
+		return (lemmaAnno);
+	}
+
+	@Override
+	public void setLemmaAnnotation(LemmaAnnotation newLemmaAnnotation) {
+		this.getAnnotations().add(newLemmaAnnotation);
+	}
+
+	@Override
+	public Document getDocument() {
+		return document;
+	}
+
+	@Override
+	public void setDocument(Document newDocument) {
+		document = newDocument;
+	}
+
+	@Override
+	public List<Span> getSpans() {
+		return spans;
+	}
+
+	/**
+	 * Checks this and given object for equality. Conditions for equality:
+	 * Object must be instance of Span, have the same name as this,
+	 * getSpans().size() must be equal, all Spans must correspond and
+	 * annotations must be equal.
+	 * 
+	 * @param obj
+	 *            An object
+	 * @return true or false
+	 */
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (!(obj instanceof Token)) {
+			return false;
+		}
+		Token tok = (Token) obj;
+
+		// ##### compare text #####
+		if (((this.getText() != null) && (!(this.getText().equals(tok.getText()))))
+				|| ((tok.getText() != null) && (!(tok.getText().equals(this.getText()))))) {
+			return false;
+		}
+
+		// ##### compare span count #####
+		if (this.getSpans().size() != tok.getSpans().size()) {
+			return false;
+		}
+
+		// ##### compare spans #####
+		for (int i = 0; i < this.getSpans().size(); i++) {
+			if (!(this.getSpans().get(i).equals(tok.getSpans().get(i)))) {
+				return false;
+			}
+		}
+
+		// okay fine, check super to compare Annotations
+		return super.equals(obj);
+	}
+
+} // TokenImpl

--- a/src/main/java/org/corpus_tools/peppermodules/treetagger/model/impl/TreetaggerFactoryImpl.java
+++ b/src/main/java/org/corpus_tools/peppermodules/treetagger/model/impl/TreetaggerFactoryImpl.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright 2009 Humboldt-Universität zu Berlin, INRIA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+package org.corpus_tools.peppermodules.treetagger.model.impl;
+
+import org.corpus_tools.peppermodules.treetagger.model.Annotation;
+import org.corpus_tools.peppermodules.treetagger.model.AnyAnnotation;
+import org.corpus_tools.peppermodules.treetagger.model.Document;
+import org.corpus_tools.peppermodules.treetagger.model.LemmaAnnotation;
+import org.corpus_tools.peppermodules.treetagger.model.POSAnnotation;
+import org.corpus_tools.peppermodules.treetagger.model.Span;
+import org.corpus_tools.peppermodules.treetagger.model.Token;
+import org.corpus_tools.peppermodules.treetagger.model.TreetaggerFactory;
+
+/**
+ * <!-- begin-user-doc --> An implementation of the model <b>Factory</b>. <!--
+ * end-user-doc -->
+ * 
+ * @generated
+ */
+public class TreetaggerFactoryImpl implements TreetaggerFactory {
+	public static TreetaggerFactory init() {
+		return new TreetaggerFactoryImpl();
+	}
+
+	public TreetaggerFactoryImpl() {
+		super();
+	}
+
+	@Override
+	public Document createDocument() {
+		DocumentImpl document = new DocumentImpl();
+		return document;
+	}
+
+	@Override
+	public Token createToken() {
+		TokenImpl token = new TokenImpl();
+		return token;
+	}
+
+	@Override
+	public Annotation createAnnotation() {
+		AnnotationImpl annotation = new AnnotationImpl();
+		return annotation;
+	}
+
+	@Override
+	public POSAnnotation createPOSAnnotation() {
+		POSAnnotationImpl posAnnotation = new POSAnnotationImpl();
+		return posAnnotation;
+	}
+
+	@Override
+	public LemmaAnnotation createLemmaAnnotation() {
+		LemmaAnnotationImpl lemmaAnnotation = new LemmaAnnotationImpl();
+		return lemmaAnnotation;
+	}
+
+	@Override
+	public AnyAnnotation createAnyAnnotation() {
+		AnyAnnotationImpl anyAnnotation = new AnyAnnotationImpl();
+		return anyAnnotation;
+	}
+
+	@Override
+	public Span createSpan() {
+		SpanImpl span = new SpanImpl();
+		return span;
+	}
+
+}

--- a/src/main/java/org/corpus_tools/peppermodules/treetagger/model/resources/TabReader.java
+++ b/src/main/java/org/corpus_tools/peppermodules/treetagger/model/resources/TabReader.java
@@ -1,0 +1,453 @@
+/**
+ * Copyright 2009 Humboldt-Universität zu Berlin, INRIA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+package org.corpus_tools.peppermodules.treetagger.model.resources;
+
+import java.io.BufferedReader;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.AbstractMap.SimpleEntry;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Properties;
+import java.util.regex.Pattern;
+
+import org.corpus_tools.pepper.modules.exceptions.PepperModuleException;
+import org.corpus_tools.peppermodules.treetagger.model.AnnotatableElement;
+import org.corpus_tools.peppermodules.treetagger.model.Annotation;
+import org.corpus_tools.peppermodules.treetagger.model.Document;
+import org.corpus_tools.peppermodules.treetagger.model.LemmaAnnotation;
+import org.corpus_tools.peppermodules.treetagger.model.POSAnnotation;
+import org.corpus_tools.peppermodules.treetagger.model.Span;
+import org.corpus_tools.peppermodules.treetagger.model.Token;
+import org.corpus_tools.peppermodules.treetagger.model.TreetaggerFactory;
+import org.eclipse.emf.common.util.URI;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Resource for loading and saving of treetagger data
+ * 
+ * @author hildebax
+ * 
+ */
+public class TabReader {
+	private static final Logger logger = LoggerFactory.getLogger(TabReader.class);
+	// column seperator
+	private String separator = "\t";
+
+	private String POSName = "pos";
+	private String LemmaName = "lemma";
+
+	/**
+	 * property key for the meta tag of input
+	 */
+	public static final String propertyInputMetaTag = "treetagger.input.metaTag";
+
+	/**
+	 * property key for the encoding of input file
+	 */
+	public static final String propertyInputFileEncoding = "treetagger.input.fileEncoding";
+
+	/**
+	 * property key for the meta tag of output
+	 */
+	public static final String propertyOutputMetaTag = "treetagger.output.metaTag";
+
+	/**
+	 * property key for the encoding of output file
+	 */
+	public static final String propertyOutputFileEncoding = "treetagger.output.fileEncoding";
+
+	/**
+	 * property key for the option to export any annotation
+	 */
+	public static final String propertyExportAnyAnnotation = "treetagger.output.exportAnyAnnotation";
+
+	private static final Pattern inputColumnPattern = Pattern.compile("treetagger\\.input\\.column");
+
+	// property default values
+	private static final String defaultInputFileEncoding = "UTF-8";
+	private static final String defaultMetaTag = "meta";
+
+	// BOM character
+	private static final Character utf8BOM = new Character((char) 0xFEFF);
+
+	String currentFileName = "";
+	private URI location = null;
+
+	private Properties properties = null;
+	private List<Document> documents = new ArrayList<>();
+
+	/**
+	 * Getter for the Properties
+	 * 
+	 * @return properties
+	 */
+	public Properties getProperties() {
+		if (properties == null) {
+			properties = new Properties();
+		}
+		return properties;
+	}
+
+	/*
+	 * auxilliary method for processing input file
+	 */
+	private void addAttributesAsAnnotations(String tag, AnnotatableElement annotatableElement) {
+		ArrayList<SimpleEntry<String, String>> attributeValueList = XMLUtils.getAttributeValueList(tag);
+		for (int i = 0; i < attributeValueList.size(); i++) {
+			SimpleEntry<String, String> entry = attributeValueList.get(i);
+			Annotation annotation = TreetaggerFactory.eINSTANCE.createAnnotation();
+			annotation.setName(entry.getKey());
+			annotation.setValue(entry.getValue());
+			annotatableElement.getAnnotations().add(annotation);
+		}
+	}
+
+	private Document currentDocument = null;
+	private ArrayList<Span> openSpans = new ArrayList<Span>();
+	private int fileLineCount = 0;
+	private boolean xmlDocumentOpen = false;
+	private HashMap<Integer, String> columnMap = null;
+	private ArrayList<Integer> dataRowsWithTooMuchColumns = new ArrayList<Integer>();
+	private ArrayList<Integer> dataRowsWithTooLessColumns = new ArrayList<Integer>();
+
+	/*
+	 * auxilliary method for processing input file
+	 */
+	private void beginDocument(String startTag) {
+		if (this.currentDocument != null) {
+			this.endDocument();
+		}
+		this.currentDocument = TreetaggerFactory.eINSTANCE.createDocument();
+		this.xmlDocumentOpen = (startTag != null);
+		if (this.xmlDocumentOpen) {
+			addAttributesAsAnnotations(startTag, this.currentDocument);
+		}
+	}
+
+	/*
+	 * auxilliary method for processing input file
+	 */
+	private void endDocument() {
+		if (this.currentDocument != null) {
+			if (!this.openSpans.isEmpty()) {
+				String openSpanNames = "";
+				for (int spanIndex = 0; spanIndex < this.openSpans.size(); spanIndex++) {
+					Span span = this.openSpans.get(spanIndex);
+					openSpanNames += ",</" + span.getName() + ">";
+					for (int tokenIndex = span.getTokens().size() - 1; tokenIndex >= 0; tokenIndex--) {
+						Token token = span.getTokens().get(tokenIndex);
+						if (token.getSpans().contains(span)) {
+							token.getSpans().remove(span);
+						} else {
+							break;
+						}
+					}
+				}
+				logger.warn(String.format("input file '%s' (line %d): missing end tag(s) '%s'. tag(s) will be ignored!",
+						location.lastSegment(), this.fileLineCount, openSpanNames.substring(1)));
+			}
+			if (this.xmlDocumentOpen) {
+				logger.warn(
+						String.format("input file '%s' (line %d): missing document end tag. document will be ignored!",
+								location.lastSegment(), this.fileLineCount));
+			} else {
+				documents.add(this.currentDocument);
+			}
+
+			this.currentDocument = null;
+			this.xmlDocumentOpen = false;
+		}
+		this.openSpans.clear();
+	}
+
+	/*
+	 * auxilliary method for processing input file
+	 */
+	private void beginSpan(String spanName, String startTag) {
+		if (this.currentDocument == null) {
+			this.beginDocument(null);
+		}
+		Span span = TreetaggerFactory.eINSTANCE.createSpan();
+		this.openSpans.add(0, span);
+		span.setName(spanName);
+		addAttributesAsAnnotations(startTag, span);
+	}
+
+	/*
+	 * auxilliary method for processing input file
+	 */
+	private void endSpan(String spanName) {
+		if (this.currentDocument == null) {
+			logger.warn(
+					String.format("input file '%s' (line '%d'): end tag '</%s>' out of nowhere. tag will be ignored!",
+							location.lastSegment(), this.fileLineCount, spanName));
+		} else {
+			boolean matchingStartTagExists = false;
+			for (int i = 0; i < this.openSpans.size(); i++) {
+				Span openSpan = this.openSpans.get(i);
+				if (openSpan.getName().equalsIgnoreCase(spanName)) {
+					matchingStartTagExists = true;
+					if (openSpan.getTokens().isEmpty()) {
+						logger.warn(String.format(
+								"input file '%s' (line %d): no tokens contained in span '<%s>'. span will be ignored!",
+								location.lastSegment(), this.fileLineCount, openSpan.getName()));
+					}
+					this.openSpans.remove(i);
+					break;
+				}
+			}
+			if (!matchingStartTagExists) {
+				logger.warn(String.format(
+						"input file '%s' (line %d): no corresponding opening tag found for end tag '</%s>'. tag will be ignored!",
+						location.lastSegment(), this.fileLineCount, spanName));
+			}
+		}
+	}
+
+	/*
+	 * auxilliary method for processing input file
+	 */
+	private void addDataRow(String row) {
+		if (this.currentDocument == null) {
+			this.beginDocument(null);
+		}
+		String[] tuple = row.split(separator);
+		Token token = TreetaggerFactory.eINSTANCE.createToken();
+		this.currentDocument.getTokens().add(token);
+		token.setText(tuple[0]);
+		for (int i = 0; i < this.openSpans.size(); i++) {
+			Span span = openSpans.get(i);
+			token.getSpans().add(span);
+			span.getTokens().add(token);
+		}
+
+		if (tuple.length > this.columnMap.size() + 1) {
+			this.dataRowsWithTooMuchColumns.add(this.fileLineCount);
+		} else if (tuple.length <= this.columnMap.size()) {
+			this.dataRowsWithTooLessColumns.add(this.fileLineCount);
+		}
+
+		for (int index = 1; index < Math.min(this.columnMap.size() + 1, tuple.length); index++) {
+			Annotation anno = null;
+			String columnName = this.columnMap.get(index);
+			if (columnName.equalsIgnoreCase(this.POSName)) {
+				anno = TreetaggerFactory.eINSTANCE.createPOSAnnotation();
+				token.setPosAnnotation((POSAnnotation) anno);
+			} else if (columnName.equalsIgnoreCase(this.LemmaName)) {
+				anno = TreetaggerFactory.eINSTANCE.createLemmaAnnotation();
+				token.setLemmaAnnotation((LemmaAnnotation) anno);
+			} else {
+				anno = TreetaggerFactory.eINSTANCE.createAnyAnnotation();
+				anno.setName(columnName);
+				token.getAnnotations().add(anno);
+			}
+			anno.setValue(tuple[index]);
+		}
+	}
+
+	/*
+	 * auxilliary method for processing input file
+	 */
+	private void setDocumentNames() {
+		String documentBaseName = location.lastSegment().split("[.]")[0];
+		int documentCount = documents.size();
+
+		switch (documentCount) {
+		case 0:
+			logger.warn(String.format("no valid document data contained in file '%s'", location.toFileString()));
+			break;
+		case 1:
+			// set simple document name
+			documents.get(0).setName(documentBaseName);
+			break;
+		default:
+			// set document names with leading zeros for number extensions
+			int documentCountDigits = String.valueOf(documentCount).length();
+			for (int docIndex = 0; docIndex < documentCount; docIndex++) {
+				String docNumber = Integer.toString(docIndex);
+				while (docNumber.length() < documentCountDigits) {
+					docNumber = "0" + docNumber;
+				}
+				documents.get(docIndex).setName(documentBaseName + "_" + docNumber);
+			}
+			break;
+		}
+	}
+
+	/**
+	 * validates and return the input columns definition from the properties
+	 * file
+	 */
+	protected HashMap<Integer, String> getColumns() {
+		HashMap<Integer, String> retVal = new HashMap<Integer, String>();
+		Object[] keyArray = this.getProperties().keySet().toArray();
+		int numOfKeys = this.getProperties().size();
+		String errorMessage = null;
+
+		for (int keyIndex = 0; keyIndex < numOfKeys; keyIndex++) {
+
+			String key = (String) keyArray[keyIndex];
+			if (inputColumnPattern.matcher(key).find()) {
+
+				// try to extract the number at the end of the key
+				String indexStr = key.substring("treetagger.input.column".length());
+				String name = this.getProperties().getProperty(key);
+				Integer index = null;
+
+				try {
+					index = Integer.valueOf(indexStr);
+				} catch (NumberFormatException e) {
+					errorMessage = "Invalid property name '" + key + "': " + indexStr + " is not a valid number!";
+					logger.error(errorMessage);
+					throw new PepperModuleException(errorMessage, e);
+				}
+
+				// minimal index is 1
+				if (index <= 0) {
+					errorMessage = "Invalid settings in properties file: no column index less than 1 allowed!";
+					logger.error(errorMessage);
+					throw new PepperModuleException(errorMessage);
+				}
+
+				// with the standard Properties class, this can never happen...
+				if (retVal.containsKey(index)) {
+					errorMessage = "Invalid settings in properties file:  More than one column is defined for index '"
+							+ index + "'";
+					logger.error(errorMessage);
+					throw new PepperModuleException(errorMessage);
+				}
+
+				if (retVal.containsValue(name)) {
+					errorMessage = "Invalid settings in properties file:  More than one column is defined for name '"
+							+ name + "'";
+					logger.error(errorMessage);
+					throw new PepperModuleException(errorMessage);
+				}
+
+				retVal.put(index, name);
+			}
+		}
+
+		// return defaults if nothing is set in the properties file
+		if (retVal.size() == 0) {
+			retVal.put(1, this.POSName);
+			retVal.put(2, this.LemmaName);
+			return retVal;
+		}
+
+		// check consecutivity of indexes
+		for (int index = 1; index <= retVal.size(); index++) {
+			if (!retVal.containsKey(index)) {
+				errorMessage = "Invalid settings in properties file: column indexes are not consecutive, column" + index
+						+ " missing!";
+				logger.error(errorMessage);
+				throw new PepperModuleException(errorMessage);
+			}
+		}
+		return retVal;
+	}
+
+	/**
+	 * Loads a resource into treetagger model from tab separated file.
+	 * 
+	 * @param options
+	 *            a map that may contain an instance of LogService and an
+	 *            instance of Properties, with {@link #logServiceKey} and
+	 *            {@link #propertiesKey} respectively as keys
+	 */
+	public List<Document> load(URI location, java.util.Map<?, ?> options) {
+		this.openSpans.clear();
+		this.currentDocument = null;
+		this.fileLineCount = 0;
+		this.xmlDocumentOpen = false;
+
+		if (options != null) {
+			getProperties().putAll(options);
+		}
+
+		if (location == null) {
+			throw new PepperModuleException("Cannot load any resource, because no uri is given.");
+		}
+		this.location = location;
+		this.currentFileName = location.toFileString();
+
+		String metaTag = getProperties().getProperty(propertyInputMetaTag, defaultMetaTag);
+		logger.info("using meta tag '{}'", metaTag);
+
+		String fileEncoding = getProperties().getProperty(propertyInputFileEncoding, defaultInputFileEncoding);
+		logger.info("using input file encoding '{}'", fileEncoding);
+
+		this.columnMap = getColumns();
+
+		try (BufferedReader fileReader = new BufferedReader(
+				new InputStreamReader(new FileInputStream(this.currentFileName), fileEncoding));) {
+			String line = null;
+			this.fileLineCount = 0;
+			while ((line = fileReader.readLine()) != null) {
+				if (line.trim().length() > 0) {
+					// delete BOM if exists
+					if ((this.fileLineCount == 0) && (line.startsWith(utf8BOM.toString()))) {
+						line = line.substring(utf8BOM.toString().length());
+						logger.info("BOM recognised and ignored");
+					}
+					this.fileLineCount++;
+					if (XMLUtils.isProcessingInstructionTag(line)) {
+						// do nothing; ignore processing instructions
+					} else if (XMLUtils.isStartTag(line)) {
+						String startTagName = XMLUtils.getName(line);
+						if (startTagName.equalsIgnoreCase(metaTag)) {
+							this.beginDocument(line);
+						} else {
+							this.beginSpan(startTagName, line);
+						}
+					} else if (XMLUtils.isEndTag(line)) {
+						String endTagName = XMLUtils.getName(line);
+						if (endTagName.equalsIgnoreCase(metaTag)) {
+							this.xmlDocumentOpen = false;
+							this.endDocument();
+						} else {
+							this.endSpan(endTagName);
+						}
+					} else {
+						this.addDataRow(line);
+					}
+				}
+			}
+			this.endDocument();
+		} catch (IOException e) {
+			throw new PepperModuleException("Cannot read treetagger file '" + location + "'. ", e);
+		}
+
+		this.setDocumentNames();
+
+		if (this.dataRowsWithTooLessColumns.size() > 0) {
+			logger.warn(String.format("%s rows in input file had less data columns than expected! (Rows %s)",
+					this.dataRowsWithTooLessColumns.size(), this.dataRowsWithTooLessColumns.toString()));
+		}
+		if (this.dataRowsWithTooMuchColumns.size() > 0) {
+			logger.warn(String.format(
+					"%s rows in input file had more data columns than expected! Additional data was ignored! (Rows %s)",
+					this.dataRowsWithTooMuchColumns.size(), this.dataRowsWithTooMuchColumns.toString()));
+		}
+		return documents;
+	}
+}

--- a/src/main/java/org/corpus_tools/peppermodules/treetagger/model/resources/TabWriter.java
+++ b/src/main/java/org/corpus_tools/peppermodules/treetagger/model/resources/TabWriter.java
@@ -1,0 +1,397 @@
+/**
+ * Copyright 2009 Humboldt-Universität zu Berlin, INRIA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+package org.corpus_tools.peppermodules.treetagger.model.resources;
+
+import java.io.BufferedWriter;
+import java.io.FileOutputStream;
+import java.io.OutputStreamWriter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Properties;
+import java.util.regex.Pattern;
+
+import org.corpus_tools.pepper.modules.exceptions.PepperModuleException;
+import org.corpus_tools.peppermodules.treetagger.model.Annotation;
+import org.corpus_tools.peppermodules.treetagger.model.AnyAnnotation;
+import org.corpus_tools.peppermodules.treetagger.model.Document;
+import org.corpus_tools.peppermodules.treetagger.model.Span;
+import org.corpus_tools.peppermodules.treetagger.model.Token;
+import org.eclipse.emf.common.util.URI;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Resource for loading and saving of treetagger data
+ * 
+ * @author hildebax
+ * 
+ */
+public class TabWriter {
+	private static final Logger logger = LoggerFactory.getLogger(TabWriter.class);
+	// column seperator
+	private String separator = "\t";
+
+	private String POSName = "pos";
+	private String LemmaName = "lemma";
+
+	/**
+	 * property key for the meta tag of input
+	 */
+	public static final String propertyInputMetaTag = "treetagger.input.metaTag";
+
+	/**
+	 * property key for the encoding of input file
+	 */
+	public static final String propertyInputFileEncoding = "treetagger.input.fileEncoding";
+
+	/**
+	 * property key for the meta tag of output
+	 */
+	public static final String propertyOutputMetaTag = "treetagger.output.metaTag";
+
+	/**
+	 * property key for the encoding of output file
+	 */
+	public static final String propertyOutputFileEncoding = "treetagger.output.fileEncoding";
+
+	/**
+	 * property key for the option to export any annotation
+	 */
+	public static final String propertyExportAnyAnnotation = "treetagger.output.exportAnyAnnotation";
+
+	private static final Pattern inputColumnPattern = Pattern.compile("treetagger\\.input\\.column");
+
+	// property default values
+	private static final String defaultOutputFileEncoding = "UTF-8";
+	private static final String defaultMetaTag = "meta";
+	private static final String defaultExportAnyAnnotation = "true";
+
+	String currentFileName = "";
+	URI location = null;
+
+	private Properties properties = null;
+
+	/**
+	 * Getter for the Properties
+	 * 
+	 * @return properties
+	 */
+	public Properties getProperties() {
+		if (properties == null) {
+			properties = new Properties();
+		}
+		return properties;
+	}
+
+	/**
+	 * Stores a treetagger model into tab separated file
+	 * 
+	 * @param options
+	 *            a map that may contain an instance of LogService and an
+	 *            instance of Properties, with {@link #logServiceKey} and
+	 *            {@link #propertiesKey} respectively as keys
+	 */
+	public void save(Document document, URI location, java.util.Map<?, ?> options) throws java.io.IOException {
+		if (options != null) {
+			getProperties().putAll(options);
+		}
+		if (document == null) {
+			throw new PepperModuleException("Cannot treetagger document, because the passed document was empty.");
+		}
+		this.location = location;
+		this.currentFileName = location.toFileString();
+
+		String metaTag = getProperties().getProperty(propertyOutputMetaTag, defaultMetaTag);
+		logger.info(String.format("using meta tag '%s'", metaTag));
+
+		String fileEncoding = getProperties().getProperty(propertyOutputFileEncoding, defaultOutputFileEncoding);
+		logger.info(String.format("using output file encoding '%s'", fileEncoding));
+
+		boolean exportAnyAnnotation = getProperties()
+				.getProperty(propertyExportAnyAnnotation, defaultExportAnyAnnotation).equalsIgnoreCase("true");
+		logger.info("exporting any annotation = " + exportAnyAnnotation);
+
+		BufferedWriter fileWriter = new BufferedWriter(
+				new OutputStreamWriter(new FileOutputStream(this.currentFileName), fileEncoding));
+		try {
+
+			// this list and this hashmap are used if any annotation is
+			// to be exported
+			// the list will contain the sorted names of all annotation
+			// names occuring on all tokens in the document
+			// the map will map from token index to another map, which
+			// maps from annotation name to AnyAnotation
+			ArrayList<String> columnNamesList = null;
+			HashMap<Integer, HashMap<String, AnyAnnotation>> tokenMap = null;
+
+			if (exportAnyAnnotation) {
+				// calculate number of columns and collect their names
+				HashSet<String> annoNamesSet = new HashSet<String>();
+				tokenMap = new HashMap<Integer, HashMap<String, AnyAnnotation>>();
+				for (Integer tokenIndex = 0; tokenIndex < document.getTokens().size(); tokenIndex++) {
+					Token token = document.getTokens().get(tokenIndex);
+					List<Annotation> annotationList = token.getAnnotations();
+					if ((token.getPosAnnotation() != null) && (token.getLemmaAnnotation() != null)
+							&& (annotationList.size() > 2)) {
+						tokenMap.put(tokenIndex, new HashMap<String, AnyAnnotation>());
+						HashMap<String, AnyAnnotation> annoMap = tokenMap.get(tokenIndex);
+						for (int annotationIndex = 0; annotationIndex < annotationList.size(); annotationIndex++) {
+							Annotation annotation = annotationList.get(annotationIndex);
+							if (annotation instanceof AnyAnnotation) {
+								String annotationName = annotation.getName();
+								annoNamesSet.add(annotationName);
+								annoMap.put(annotationName, (AnyAnnotation) annotation);
+							}
+						}
+					}
+				}
+				// sort columns
+				columnNamesList = new ArrayList<String>(annoNamesSet);
+				Collections.sort(columnNamesList);
+				logger.info(
+						"The following columns appear in the output file additionally to word form, part-of-speech and lemma: "
+								+ columnNamesList.toString());
+			}
+
+			fileWriter.write(String.format("<%s", metaTag));
+			for (int i = 0; i < document.getAnnotations().size(); i++) {
+				Annotation annotation = document.getAnnotations().get(i);
+				fileWriter.write(String.format(" %s=\"%s\"", annotation.getName(), annotation.getValue()));
+			}
+			fileWriter.write(">\n");
+
+			ArrayList<Span> spanList = new ArrayList<Span>();
+			HashMap<String, Integer> spanNamesCounts = new HashMap<String, Integer>();
+
+			for (Integer tokenIndex = 0; tokenIndex < document.getTokens().size(); tokenIndex++) {
+				Token token = document.getTokens().get(tokenIndex);
+
+				// write end tags
+				for (int spanIndex = spanList.size() - 1; spanIndex >= 0; spanIndex--) {
+					Span span = spanList.get(spanIndex);
+					if (!token.getSpans().contains(span)) {
+						String spanName = span.getName();
+						fileWriter.write("</" + spanName + ">\n");
+						spanList.remove(span);
+						Integer spanNameCount = spanNamesCounts.get(spanName);
+						if (spanNameCount == 1) {
+							spanNamesCounts.remove(spanName);
+						} else {
+							spanNamesCounts.put(spanName, spanNameCount - 1);
+						}
+					}
+				}
+
+				// calculate order for new opening tags by number of
+				// tokens contained in spans ("size" of span)
+				// if new opening spans have different sizes, the bigger
+				// ones must open before the smaller
+
+				// for each occuring span size, a key is put into this
+				// map, mapping to a list of spans with this size
+				HashMap<Integer, ArrayList<Span>> size2SpanlistMap = new HashMap<Integer, ArrayList<Span>>();
+				// this list is used to have all occuring sizes sortable
+				// without much converting of the maps keySet
+				ArrayList<Integer> sizeList = new ArrayList<Integer>();
+				for (int spanIndex = token.getSpans().size() - 1; spanIndex >= 0; spanIndex--) {
+					Span span = token.getSpans().get(spanIndex);
+					Integer spanSize = span.getTokens().size();
+					if (!spanList.contains(span)) {
+						if (!size2SpanlistMap.containsKey(spanSize)) {
+							size2SpanlistMap.put(spanSize, new ArrayList<Span>());
+							sizeList.add(spanSize);
+						}
+						size2SpanlistMap.get(spanSize).add(span);
+					}
+				}
+				Collections.sort(sizeList);
+				Collections.reverse(sizeList);
+				// write opening tags in xml conform order
+				for (int sizeIndex = 0; sizeIndex < sizeList.size(); sizeIndex++) {
+					int size = sizeList.get(sizeIndex);
+
+					ArrayList<String> currentSpannames = new ArrayList<String>();
+					HashMap<String, ArrayList<Span>> currentSpanMap = new HashMap<String, ArrayList<Span>>();
+					{
+						ArrayList<Span> currentSpanlist = size2SpanlistMap.get(size);
+						for (int spanIndex = 0; spanIndex < currentSpanlist.size(); spanIndex++) {
+							Span span = currentSpanlist.get(spanIndex);
+							String spanName = span.getName();
+							if (!currentSpanMap.containsKey(spanName)) {
+								currentSpannames.add(spanName);
+								currentSpanMap.put(spanName, new ArrayList<Span>());
+							}
+							currentSpanMap.get(spanName).add(span);
+						}
+					}
+					Collections.sort(currentSpannames);
+
+					for (int spanNameIndex = 0; spanNameIndex < currentSpannames.size(); spanNameIndex++) {
+						String spansName = currentSpannames.get(spanNameIndex);
+						ArrayList<Span> currentSpanlist = currentSpanMap.get(spansName);
+
+						if (!spanNamesCounts.containsKey(spansName)) {
+							spanNamesCounts.put(spansName, currentSpanlist.size());
+						} else {
+							spanNamesCounts.put(spansName, spanNamesCounts.get(spansName) + currentSpanlist.size());
+						}
+						if (spanNamesCounts.get(spansName) > 1) {
+							logger.warn("There are " + spanNamesCounts.get(spansName) + " spans named " + spansName
+									+ " open at the same time!");
+						}
+						for (int spanIndex = 0; spanIndex < currentSpanlist.size(); spanIndex++) {
+							Span span = currentSpanlist.get(spanIndex);
+							spanList.add(span);
+							fileWriter.write("<" + span.getName());
+							for (Annotation anno : span.getAnnotations()) {
+								fileWriter.write(" " + anno.getName() + "=\"" + anno.getValue() + "\"");
+							}
+							fileWriter.write(">\n");
+						}
+					}
+				}
+
+				// write token data
+				fileWriter.write(token.getText());
+
+				fileWriter.write(this.separator);
+
+				Annotation anno = token.getPosAnnotation();
+				if (anno != null) {
+					fileWriter.write(anno.getValue());
+				}
+
+				fileWriter.write(this.separator);
+
+				anno = token.getLemmaAnnotation();
+				if ((anno != null) && (anno.getValue() != null)) {
+					fileWriter.write(anno.getValue());
+				}
+
+				if (exportAnyAnnotation) {
+					for (int colIndex = 0; colIndex < columnNamesList.size(); colIndex++) {
+						fileWriter.write(this.separator);
+						String columnName = columnNamesList.get(colIndex);
+						HashMap<String, AnyAnnotation> annoMap = tokenMap.get(tokenIndex);
+						if (annoMap != null) {
+							anno = annoMap.get(columnName);
+							if (anno != null) {
+								fileWriter.write(anno.getValue());
+							}
+						}
+					}
+				}
+
+				fileWriter.write("\n");
+			}
+
+			// write final end tags
+			for (int spanIndex = spanList.size() - 1; spanIndex >= 0; spanIndex--) {
+				Span span = spanList.get(spanIndex);
+				fileWriter.write("</" + span.getName() + ">\n");
+				spanList.remove(span);
+			}
+
+			// write end of document
+			fileWriter.write(String.format("</%s>\n", metaTag));
+
+		} catch (RuntimeException e) {
+			throw e;
+		} finally {
+			fileWriter.flush();
+			fileWriter.close();
+			fileWriter = null;
+		}
+	}
+
+	/**
+	 * validates and return the input columns definition from the properties
+	 * file
+	 */
+	protected HashMap<Integer, String> getColumns() {
+		HashMap<Integer, String> retVal = new HashMap<Integer, String>();
+		Object[] keyArray = this.getProperties().keySet().toArray();
+		int numOfKeys = this.getProperties().size();
+		String errorMessage = null;
+
+		for (int keyIndex = 0; keyIndex < numOfKeys; keyIndex++) {
+
+			String key = (String) keyArray[keyIndex];
+			if (inputColumnPattern.matcher(key).find()) {
+
+				// try to extract the number at the end of the key
+				String indexStr = key.substring("treetagger.input.column".length());
+				String name = this.getProperties().getProperty(key);
+				Integer index = null;
+
+				try {
+					index = Integer.valueOf(indexStr);
+				} catch (NumberFormatException e) {
+					errorMessage = "Invalid property name '" + key + "': " + indexStr + " is not a valid number!";
+					logger.error(errorMessage);
+					throw new PepperModuleException(errorMessage, e);
+				}
+
+				// minimal index is 1
+				if (index <= 0) {
+					errorMessage = "Invalid settings in properties file: no column index less than 1 allowed!";
+					logger.error(errorMessage);
+					throw new PepperModuleException(errorMessage);
+				}
+
+				// with the standard Properties class, this can never happen...
+				if (retVal.containsKey(index)) {
+					errorMessage = "Invalid settings in properties file:  More than one column is defined for index '"
+							+ index + "'";
+					logger.error(errorMessage);
+					throw new PepperModuleException(errorMessage);
+				}
+
+				if (retVal.containsValue(name)) {
+					errorMessage = "Invalid settings in properties file:  More than one column is defined for name '"
+							+ name + "'";
+					logger.error(errorMessage);
+					throw new PepperModuleException(errorMessage);
+				}
+
+				retVal.put(index, name);
+			}
+		}
+
+		// return defaults if nothing is set in the properties file
+		if (retVal.size() == 0) {
+			retVal.put(1, this.POSName);
+			retVal.put(2, this.LemmaName);
+			return retVal;
+		}
+
+		// check consecutivity of indexes
+		for (int index = 1; index <= retVal.size(); index++) {
+			if (!retVal.containsKey(index)) {
+				errorMessage = "Invalid settings in properties file: column indexes are not consecutive, column" + index
+						+ " missing!";
+				logger.error(errorMessage);
+				throw new PepperModuleException(errorMessage);
+			}
+		}
+		return retVal;
+	}
+}

--- a/src/main/java/org/corpus_tools/peppermodules/treetagger/model/resources/XMLUtils.java
+++ b/src/main/java/org/corpus_tools/peppermodules/treetagger/model/resources/XMLUtils.java
@@ -1,0 +1,228 @@
+/**
+ * Copyright 2009 Humboldt-Universität zu Berlin, INRIA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+package org.corpus_tools.peppermodules.treetagger.model.resources;
+
+import java.util.AbstractMap.SimpleEntry;
+import java.util.ArrayList;
+import java.util.Hashtable;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Utilities for XML processing
+ * 
+ * @author hildebax
+ * @version 1.0.0
+ */
+public class XMLUtils {
+
+	private static final Character x09 = new Character((char) 0x09); // horizontal
+																		// tab
+	private static final Character x0A = new Character((char) 0x0A); // line
+																		// feed
+	private static final Character x0D = new Character((char) 0x0D); // carriage
+																		// return
+	private static final Character x20 = new Character((char) 0x20); // space
+	private static final Character x22 = new Character((char) 0x22); // double
+																		// quotation
+	private static final Character x27 = new Character((char) 0x27); // single
+																		// quotation
+	private static final Character xB7 = new Character((char) 0xB7); // middle
+																		// dot
+	private static final Character xC0 = new Character((char) 0xC0); // À
+	private static final Character xD6 = new Character((char) 0xD6); // Ö
+	private static final Character xD8 = new Character((char) 0xD8); //
+	private static final Character xF6 = new Character((char) 0xF6);
+	private static final Character xF8 = new Character((char) 0xF8);
+	private static final Character x02FF = new Character((char) 0x02FF);
+	private static final Character x0300 = new Character((char) 0x0300);
+	private static final Character x036F = new Character((char) 0x036F);
+	private static final Character x0370 = new Character((char) 0x0370);
+	private static final Character x037D = new Character((char) 0x037D);
+	private static final Character x037F = new Character((char) 0x037F);
+	private static final Character x1FFF = new Character((char) 0x1FFF);
+	private static final Character x200C = new Character((char) 0x200C);
+	private static final Character x200D = new Character((char) 0x200D);
+	private static final Character x203F = new Character((char) 0x203F);
+	private static final Character x2040 = new Character((char) 0x2040);
+	private static final Character x2070 = new Character((char) 0x2070);
+	private static final Character x218F = new Character((char) 0x218F);
+	private static final Character x2C00 = new Character((char) 0x2C00);
+	private static final Character x2FEF = new Character((char) 0x2FEF);
+	private static final Character x3001 = new Character((char) 0x3001);
+	private static final Character xD7FF = new Character((char) 0xD7FF);
+	private static final Character xE000 = new Character((char) 0xE000);
+	private static final Character xF900 = new Character((char) 0xF900);
+	private static final Character xFDCF = new Character((char) 0xFDCF);
+	private static final Character xFDF0 = new Character((char) 0xFDF0);
+	private static final Character xFFFD = new Character((char) 0xFFFD);
+
+	private static final String s = String.format("([%c%c%c%c]+)", x09, x0A, x0D, x20);
+	private static final String eq = "(" + s + "?=" + s + "?" + ")";
+	private static final String namestartchars = String.format(":A-Z_a-z%c-%c%c-%c%c-%c%c-%c%c-%c%c-%c%c-%c%c-%c%c-%c%c-%c%c-%c", xC0, xD6, xD8, xF6, xF8, x02FF, x0370, x037D, x037F, x1FFF, x200C, x200D, x2070, x218F, x2C00, x2FEF, x3001, xD7FF, xF900, xFDCF, xFDF0, xFFFD);
+	private static final String namechars = namestartchars + String.format("-\\.0-9%c%c-%c%c-%c", xB7, x0300, x036F, x203F, x2040);
+	private static final String namestartchar = "([" + namestartchars + "])";
+	private static final String namechar = "([" + namechars + "])";
+	private static final String name = "(" + namestartchar + namechar + "*)";
+	private static final String normalChar = String.format("[%c%c%c%c-%c%c-%c]", x09, x0A, x0D, x20, xD7FF, xE000, xFFFD);
+	private static final String entityref = "(&" + name + ";)";
+	private static final String charref = "((&#[0-9]+;)|(&#x[0-9a-fA-F]+;))";
+	private static final String reference = "(" + entityref + "|" + charref + ")";
+	private static final String attvalueSingleQuote = String.format("(%c([^<&%c]|%s)*%c)", x27, x27, reference, x27);
+	private static final String attvalueDoubleQuote = String.format("(%c([^<&%c]|%s)*%c)", x22, x22, reference, x22);
+	private static final String attvalue = String.format("(%s|%s)", attvalueSingleQuote, attvalueDoubleQuote);
+	private static final String attribute = "(" + name + eq + attvalue + ")";
+
+	public static final String startTag = "<" + name + "(" + s + attribute + ")*" + s + "?>\t*";
+	public static final String endTag = "</" + name + s + "?>\t*";
+
+	// TODO: this is just an approximation to the processing instruction syntax,
+	// could be made more precise
+	private static final String piTarget = name;
+	private static final String processingInstructionTag = "<\\?" + piTarget + "(" + s + normalChar + "*" + ")?" + "\\?>";
+
+	private static final Pattern sPattern = Pattern.compile(s);
+	private static final Pattern eqPattern = Pattern.compile(eq);
+	private static final Pattern namePattern = Pattern.compile(name);
+	private static final Pattern attributePattern = Pattern.compile(attribute);
+	private static final Pattern attvaluePattern = Pattern.compile(attvalue);
+	private static final Pattern startTagPattern = Pattern.compile(startTag);
+	private static final Pattern endTagPattern = Pattern.compile(endTag);
+	private static final Pattern processingInstructionTagPattern = Pattern.compile(processingInstructionTag);
+
+	/**
+	 * Returns true if input is a <a
+	 * href="http://www.w3.org/TR/2008/REC-xml-20081126/#NT-S">white space
+	 * expression</a> according to XML specification.
+	 * 
+	 * @param input
+	 *            the expression
+	 * @return true or false
+	 */
+	public static final boolean isWhiteSpace(String input) {
+		return sPattern.matcher(input).matches();
+	}
+
+	/**
+	 * Returns true if input is an <a
+	 * href="http://www.w3.org/TR/2008/REC-xml-20081126/#NT-Eq">eq
+	 * expression</a> according to XML specification.
+	 * 
+	 * @param input
+	 *            the expression
+	 * @return true or false
+	 */
+	public static final boolean isEq(String input) {
+		return eqPattern.matcher(input).matches();
+	}
+
+	/**
+	 * Returns true if input is a <a
+	 * href="http://www.w3.org/TR/2008/REC-xml-20081126/#sec-starttags">start
+	 * tag expression</a> according to XML specification.
+	 * 
+	 * @param input
+	 *            the expression
+	 * @return true or false
+	 */
+	public static final boolean isStartTag(String input) {
+		return startTagPattern.matcher(input).matches();
+	}
+
+	/**
+	 * Returns true if input is an <a
+	 * href="http://www.w3.org/TR/2008/REC-xml-20081126/#sec-starttags">end tag
+	 * expression</a> according to XML specification.
+	 * 
+	 * @param input
+	 *            the expression
+	 * @return true or false
+	 */
+	public static final boolean isEndTag(String input) {
+		return endTagPattern.matcher(input).matches();
+	}
+
+	/**
+	 * Returns true if input is a processing instruction expression.
+	 * 
+	 * @param input
+	 *            the expression
+	 * @return true or false
+	 */
+	public static final boolean isProcessingInstructionTag(String input) {
+		return processingInstructionTagPattern.matcher(input).matches();
+	}
+
+	/**
+	 * Returns the first match of a <a
+	 * href="http://www.w3.org/TR/2008/REC-xml-20081126/#NT-Name">name</a> in
+	 * the input according to the XML specifications. If there is no match,
+	 * <code>null</code> is returned.
+	 * 
+	 * @param input
+	 *            the expression containing the name
+	 * @return the name or <code>null</code>
+	 */
+	public static final String getName(String input) {
+		Matcher matcher = namePattern.matcher(input);
+		if (matcher.find()) {
+			return matcher.group();
+		}
+		return null;
+	}
+
+	/**
+	 * Returns a list of attribute-value-pairs from the input string
+	 * 
+	 * @param input
+	 *            the expression
+	 * @return the list
+	 */
+	public static final ArrayList<SimpleEntry<String, String>> getAttributeValueList(String input) {
+		ArrayList<SimpleEntry<String, String>> list = new ArrayList<SimpleEntry<String, String>>();
+		Matcher attrMatcher = attributePattern.matcher(input);
+		while (attrMatcher.find()) {
+			Matcher attrNameMatcher = namePattern.matcher(attrMatcher.group());
+			attrNameMatcher.find();
+			String arg0 = attrNameMatcher.group();
+			Matcher attrValueMatcher = attvaluePattern.matcher(attrMatcher.group());
+			attrValueMatcher.find();
+			String arg1 = attrValueMatcher.group();
+			arg1 = arg1.substring(1, arg1.length() - 1);
+			list.add(new SimpleEntry<String, String>(arg0, arg1));
+		}
+		return list;
+	}
+
+	/**
+	 * Returns a Hashtable of attribute-value-pairs from the input string
+	 * 
+	 * @param input
+	 *            the expression
+	 * @return the Hashtable
+	 */
+	public static final Hashtable<String, String> getAttributeValueTable(String input) {
+		Hashtable<String, String> table = new Hashtable<String, String>();
+		ArrayList<SimpleEntry<String, String>> list = XMLUtils.getAttributeValueList(input);
+		for (int i = 0; i < list.size(); i++) {
+			SimpleEntry<String, String> entry = list.get(i);
+			table.put(entry.getKey(), entry.getValue());
+		}
+		return table;
+	}
+}

--- a/src/test/java/org/corpus_tools/peppermodules/treetagger/mapper/PublicSalt2TreetaggerMapper.java
+++ b/src/test/java/org/corpus_tools/peppermodules/treetagger/mapper/PublicSalt2TreetaggerMapper.java
@@ -15,34 +15,36 @@
  *
  *
  */
-package org.corpus_tools.peppermodules.treetagger.tests;
+package org.corpus_tools.peppermodules.treetagger.mapper;
 
 import java.util.Set;
 
-import org.corpus_tools.peppermodules.treetagger.mapper.Salt2TreetaggerMapper;
+import org.corpus_tools.peppermodules.treetagger.model.Document;
+import org.corpus_tools.peppermodules.treetagger.model.Span;
+import org.corpus_tools.peppermodules.treetagger.model.Token;
 import org.corpus_tools.salt.common.SDocumentGraph;
 import org.corpus_tools.salt.common.SSpan;
 import org.corpus_tools.salt.common.SToken;
 import org.corpus_tools.salt.core.SMetaAnnotation;
 
-import de.hu_berlin.german.korpling.saltnpepper.misc.treetagger.Document;
-import de.hu_berlin.german.korpling.saltnpepper.misc.treetagger.Span;
-import de.hu_berlin.german.korpling.saltnpepper.misc.treetagger.Token;
-
 public class PublicSalt2TreetaggerMapper extends Salt2TreetaggerMapper {
 
+	@Override
 	public void addDocumentAnnotations(Set<SMetaAnnotation> sMetaAnnotations, Document tDocument) {
 		super.addDocumentAnnotations(sMetaAnnotations, tDocument);
 	}
 
+	@Override
 	public void addTokens(SDocumentGraph sDocumentGraph, Document tDocument) {
 		super.addTokens(sDocumentGraph, tDocument);
 	}
 
+	@Override
 	public void addTokenAnnotations(SToken sToken, Token tToken) {
 		super.addTokenAnnotations(sToken, tToken);
 	}
 
+	@Override
 	public Span createSpan(SSpan sSpan) {
 		return super.createSpan(sSpan);
 	}

--- a/src/test/java/org/corpus_tools/peppermodules/treetagger/mapper/PublicTreetagger2SaltMapper.java
+++ b/src/test/java/org/corpus_tools/peppermodules/treetagger/mapper/PublicTreetagger2SaltMapper.java
@@ -15,20 +15,19 @@
  *
  *
  */
-package org.corpus_tools.peppermodules.treetagger.tests;
+package org.corpus_tools.peppermodules.treetagger.mapper;
 
 import java.util.List;
 
 import org.corpus_tools.peppermodules.treetagger.mapper.Treetagger2SaltMapper;
+import org.corpus_tools.peppermodules.treetagger.model.Annotation;
+import org.corpus_tools.peppermodules.treetagger.model.Document;
+import org.corpus_tools.peppermodules.treetagger.model.Token;
 import org.corpus_tools.salt.common.SDocument;
 import org.corpus_tools.salt.common.STextualDS;
 import org.corpus_tools.salt.common.STextualRelation;
 import org.corpus_tools.salt.common.SToken;
 import org.corpus_tools.salt.core.SAnnotation;
-
-import de.hu_berlin.german.korpling.saltnpepper.misc.treetagger.Annotation;
-import de.hu_berlin.german.korpling.saltnpepper.misc.treetagger.Document;
-import de.hu_berlin.german.korpling.saltnpepper.misc.treetagger.Token;
 
 public class PublicTreetagger2SaltMapper extends Treetagger2SaltMapper {
 
@@ -38,22 +37,27 @@ public class PublicTreetagger2SaltMapper extends Treetagger2SaltMapper {
 		super.mapSDocument();
 	}
 
+	@Override
 	public void addMetaAnnotation(List<Annotation> tAnnotations, SDocument sDocument) {
 		super.addMetaAnnotation(tAnnotations, sDocument);
 	}
 
+	@Override
 	public STextualDS createSTextualDS(List<Token> tTokens, SDocument sDocument) {
 		return super.createSTextualDS(tTokens, sDocument);
 	}
 
+	@Override
 	public SToken createSToken(Token tToken) {
 		return super.createSToken(tToken);
 	}
 
+	@Override
 	public SAnnotation createAnnotation(Annotation tAnnotation) {
 		return super.createAnnotation(tAnnotation);
 	}
 
+	@Override
 	public STextualRelation createSTextualRelation(SToken sToken, STextualDS sText, int start, int end) {
 		return super.createSTextualRelation(sToken, sText, start, end);
 	}

--- a/src/test/java/org/corpus_tools/peppermodules/treetagger/mapper/Salt2TreetaggerMapperTest.java
+++ b/src/test/java/org/corpus_tools/peppermodules/treetagger/mapper/Salt2TreetaggerMapperTest.java
@@ -15,7 +15,7 @@
  *
  *
  */
-package org.corpus_tools.peppermodules.treetagger.tests;
+package org.corpus_tools.peppermodules.treetagger.mapper;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -29,6 +29,13 @@ import java.util.List;
 import java.util.Set;
 
 import org.corpus_tools.peppermodules.treetagger.TreetaggerExporterProperties;
+import org.corpus_tools.peppermodules.treetagger.model.Annotation;
+import org.corpus_tools.peppermodules.treetagger.model.Document;
+import org.corpus_tools.peppermodules.treetagger.model.LemmaAnnotation;
+import org.corpus_tools.peppermodules.treetagger.model.POSAnnotation;
+import org.corpus_tools.peppermodules.treetagger.model.Span;
+import org.corpus_tools.peppermodules.treetagger.model.Token;
+import org.corpus_tools.peppermodules.treetagger.model.TreetaggerFactory;
 import org.corpus_tools.salt.SaltFactory;
 import org.corpus_tools.salt.common.SDocument;
 import org.corpus_tools.salt.common.SDocumentGraph;
@@ -47,14 +54,6 @@ import org.corpus_tools.salt.util.SaltUtil;
 import org.eclipse.emf.common.util.URI;
 import org.junit.Before;
 import org.junit.Test;
-
-import de.hu_berlin.german.korpling.saltnpepper.misc.treetagger.Annotation;
-import de.hu_berlin.german.korpling.saltnpepper.misc.treetagger.Document;
-import de.hu_berlin.german.korpling.saltnpepper.misc.treetagger.LemmaAnnotation;
-import de.hu_berlin.german.korpling.saltnpepper.misc.treetagger.POSAnnotation;
-import de.hu_berlin.german.korpling.saltnpepper.misc.treetagger.Span;
-import de.hu_berlin.german.korpling.saltnpepper.misc.treetagger.Token;
-import de.hu_berlin.german.korpling.saltnpepper.misc.treetagger.TreetaggerFactory;
 
 /**
  * TestCase for mapping from Salt to Treetagger
@@ -100,7 +99,7 @@ public class Salt2TreetaggerMapperTest {
 				sTextualDS.setText("Is this example more complicated than it appears to be?");
 				// adding the text to the document-graph
 				sDocGraph.addNode(sTextualDS);
-			}// creating the primary text
+			} // creating the primary text
 
 			{// creating tokenization (token objects and relations between
 				// tokens and the primary data object)
@@ -229,9 +228,10 @@ public class Salt2TreetaggerMapperTest {
 					sTextRel.setStart(52);
 					sTextRel.setEnd(54);
 					sDocGraph.addRelation(sTextRel);
-				}// creating the rest of the tokenization, this can also be done
+				} // creating the rest of the tokenization, this can also be
+					// done
 					// automatically
-			}// creating tokenization (token objects and relations between
+			} // creating tokenization (token objects and relations between
 				// tokens and the primary data object)
 
 			// a synchronized list of all tokens to walk through
@@ -251,24 +251,26 @@ public class Salt2TreetaggerMapperTest {
 						sPOSAnno.setValue(posAnnotations[i]);
 						sTokens.get(i).addAnnotation(sPOSAnno);
 					}
-				}// adding part-of speech annotations
+				} // adding part-of speech annotations
 
 				{// adding lemma annotations
 					SLemmaAnnotation sLemmaAnno = null;
 
 					// a list of all lemma annotations for the words Is (be),
 					// this (this) ... be (be)
-					String[] lemmaAnnotations = { "be", "this", "example", "more", "complicated", "than", "it", "appear", "to", "be" };
+					String[] lemmaAnnotations = { "be", "this", "example", "more", "complicated", "than", "it",
+							"appear", "to", "be" };
 					for (int i = 0; i < sTokens.size(); i++) {
 						sLemmaAnno = SaltFactory.createSLemmaAnnotation();
 						sLemmaAnno.setValue(lemmaAnnotations[i]);
 						sTokens.get(i).addAnnotation(sLemmaAnno);
 					}
-				}// adding lemma annotations
+				} // adding lemma annotations
 
 				{// creating annotations for information structure with the use
 					// of spans: "Is"=
-					// contrast-focus,"this example more complicated than it appears to be"=
+					// contrast-focus,"this example more complicated than it
+					// appears to be"=
 					// Topic
 					SSpan sSpan = null;
 					SSpanningRelation sSpanRel = null;
@@ -310,12 +312,12 @@ public class Salt2TreetaggerMapperTest {
 							sSpanRel.setTarget(sTokens.get(i));
 							sDocGraph.addRelation(sSpanRel);
 						}
-					}// creating the second span
+					} // creating the second span
 
-				}// creating annotations for information structure with the use
+				} // creating annotations for information structure with the use
 					// of spans
 
-			}// adding some annotations, part-of-speech and lemma (for part-of
+			} // adding some annotations, part-of-speech and lemma (for part-of
 				// speech and lemma annotations a special annotation in Salt
 				// exists)
 
@@ -352,18 +354,13 @@ public class Salt2TreetaggerMapperTest {
 				sAnno.setValue("antecedent");
 				// adding the annotation to the relation
 				sPointingRelation.addAnnotation(sAnno);
-			}// creating an anaphoric relation with the use of pointing
+			} // creating an anaphoric relation with the use of pointing
 				// relations between the Tokens {"it"} and {"this", "example"}
 
-		}// creating the document structure
+		} // creating the document structure
 		return sDocument;
 	}
 
-	/**
-	 * Test method for
-	 * {@link org.corpus_tools.peppermodules.treetagger.tests.PublicSalt2TreetaggerMapper#addDocumentAnnotations(org.eclipse.emf.common.util.EList, de.hu_berlin.german.korpling.saltnpepper.misc.treetagger.Document)}
-	 * .
-	 */
 	@Test
 	public void testAddDocumentAnnotations() {
 		Document tDoc = TreetaggerFactory.eINSTANCE.createDocument();
@@ -387,7 +384,7 @@ public class Salt2TreetaggerMapperTest {
 
 	/**
 	 * Test method for
-	 * {@link org.corpus_tools.peppermodules.treetagger.tests.PublicSalt2TreetaggerMapper#addTokens(de.hu_berlin.german.korpling.saltnpepper.salt.saltCommon.sDocumentStructure.SDocumentGraph, de.hu_berlin.german.korpling.saltnpepper.misc.treetagger.Document)}
+	 * {@link org.corpus_tools.peppermodules.treetagger.mapper.PublicSalt2TreetaggerMapper#addTokens(de.hu_berlin.german.korpling.saltnpepper.salt.saltCommon.sDocumentStructure.SDocumentGraph, de.hu_berlin.german.korpling.saltnpepper.misc.treetagger.Document)}
 	 * .
 	 */
 	@Test
@@ -458,12 +455,14 @@ public class Salt2TreetaggerMapperTest {
 		for (int annoIndex = 0; annoIndex < container.getAnnotations().size(); annoIndex++) {
 			Annotation tAnno = tAnnos.get(annoIndex);
 			if (tAnno instanceof POSAnnotation) {
-				SAnnotation sAnno = container.getAnnotation(SaltUtil.createQName(SaltUtil.SALT_NAMESPACE, SaltUtil.SEMANTICS_POS));
+				SAnnotation sAnno = container
+						.getAnnotation(SaltUtil.createQName(SaltUtil.SALT_NAMESPACE, SaltUtil.SEMANTICS_POS));
 				assertTrue(sAnno.getClass().getName(), sAnno instanceof SPOSAnnotation);
 				// do not compare SName and Name, they are set automatically
 				assertEquals(sAnno.getValue_STEXT(), tAnno.getValue());
 			} else if (tAnno instanceof LemmaAnnotation) {
-				SAnnotation sAnno = container.getAnnotation(SaltUtil.createQName(SaltUtil.SALT_NAMESPACE, SaltUtil.SEMANTICS_LEMMA));
+				SAnnotation sAnno = container
+						.getAnnotation(SaltUtil.createQName(SaltUtil.SALT_NAMESPACE, SaltUtil.SEMANTICS_LEMMA));
 				assertTrue(sAnno instanceof SLemmaAnnotation);
 				// do not compare SName and Name, they are set automatically
 				assertEquals(sAnno.getValue_STEXT(), tAnno.getValue());

--- a/src/test/java/org/corpus_tools/peppermodules/treetagger/mapper/Treetagger2SaltMapperTest.java
+++ b/src/test/java/org/corpus_tools/peppermodules/treetagger/mapper/Treetagger2SaltMapperTest.java
@@ -15,17 +15,23 @@
  *
  *
  */
-package org.corpus_tools.peppermodules.treetagger.tests;
+package org.corpus_tools.peppermodules.treetagger.mapper;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import java.io.IOException;
 import java.util.Hashtable;
 import java.util.List;
 
 import org.corpus_tools.pepper.modules.PepperModuleProperty;
 import org.corpus_tools.peppermodules.treetagger.TreetaggerImporterProperties;
+import org.corpus_tools.peppermodules.treetagger.model.Annotation;
+import org.corpus_tools.peppermodules.treetagger.model.Document;
+import org.corpus_tools.peppermodules.treetagger.model.LemmaAnnotation;
+import org.corpus_tools.peppermodules.treetagger.model.POSAnnotation;
+import org.corpus_tools.peppermodules.treetagger.model.Span;
+import org.corpus_tools.peppermodules.treetagger.model.Token;
+import org.corpus_tools.peppermodules.treetagger.model.TreetaggerFactory;
 import org.corpus_tools.salt.SaltFactory;
 import org.corpus_tools.salt.common.SDocument;
 import org.corpus_tools.salt.common.SDocumentGraph;
@@ -33,20 +39,8 @@ import org.corpus_tools.salt.common.STextualRelation;
 import org.corpus_tools.salt.common.SToken;
 import org.corpus_tools.salt.core.SMetaAnnotation;
 import org.eclipse.emf.common.util.URI;
-import org.eclipse.emf.ecore.resource.Resource;
-import org.eclipse.emf.ecore.resource.ResourceSet;
-import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
 import org.junit.Before;
 import org.junit.Test;
-
-import de.hu_berlin.german.korpling.saltnpepper.misc.treetagger.Annotation;
-import de.hu_berlin.german.korpling.saltnpepper.misc.treetagger.Document;
-import de.hu_berlin.german.korpling.saltnpepper.misc.treetagger.LemmaAnnotation;
-import de.hu_berlin.german.korpling.saltnpepper.misc.treetagger.POSAnnotation;
-import de.hu_berlin.german.korpling.saltnpepper.misc.treetagger.Span;
-import de.hu_berlin.german.korpling.saltnpepper.misc.treetagger.Token;
-import de.hu_berlin.german.korpling.saltnpepper.misc.treetagger.TreetaggerFactory;
-import de.hu_berlin.german.korpling.saltnpepper.misc.treetagger.resources.TabResourceFactory;
 
 /**
  * TestCase for mapping Treetagger to Salt
@@ -98,7 +92,8 @@ public class Treetagger2SaltMapperTest {
 		// create the Tokens and it´s Annotations
 		String[] tokens = exampleText.split(" ");
 		String[] posAnnotations = { "VBZ", "DT", "NN", "ABR", "JJ", "IN", "PRP", "VBZ", "TO", "VB" };
-		String[] lemmaAnnotations = { "be", "this", "example", "more", "complicated", "than", "it", "appear", "to", "be" };
+		String[] lemmaAnnotations = { "be", "this", "example", "more", "complicated", "than", "it", "appear", "to",
+				"be" };
 
 		for (int tokenIndex = 0; tokenIndex < tokens.length; tokenIndex++) {
 			Token token = TreetaggerFactory.eINSTANCE.createToken();
@@ -136,23 +131,26 @@ public class Treetagger2SaltMapperTest {
 		return tDocument;
 	}
 
-	/**
-	 * auxilliary method to save the data to file
-	 */
-	@SuppressWarnings("unused")
-	private void saveDocument() {
-		Document tDoc = this.createDocument();
-		ResourceSet resourceSet = new ResourceSetImpl();
-		TabResourceFactory tabResourceFactory = new TabResourceFactory();
-		resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put("tab", tabResourceFactory);
-		resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put("tt", tabResourceFactory);
-		Resource resourceOut = resourceSet.createResource(URI.createFileURI("./PublicTreetagger2SaltTest.tab"));
-		resourceOut.getContents().add(tDoc);
-		try {
-			resourceOut.save(null);
-		} catch (IOException e) {
-		}
-	}
+	// /**
+	// * auxilliary method to save the data to file
+	// */
+	// @SuppressWarnings("unused")
+	// private void saveDocument() {
+	// Document tDoc = this.createDocument();
+	// ResourceSet resourceSet = new ResourceSetImpl();
+	// TabResourceFactory tabResourceFactory = new TabResourceFactory();
+	// resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put("tab",
+	// tabResourceFactory);
+	// resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put("tt",
+	// tabResourceFactory);
+	// Resource resourceOut =
+	// resourceSet.createResource(URI.createFileURI("./PublicTreetagger2SaltTest.tab"));
+	// resourceOut.getContents().add(tDoc);
+	// try {
+	// resourceOut.save(null);
+	// } catch (IOException e) {
+	// }
+	// }
 
 	/**
 	 * Compares the names of the documents and calls the method for further
@@ -254,7 +252,8 @@ public class Treetagger2SaltMapperTest {
 
 		getFixture().setDocument(SaltFactory.createSDocument());
 
-		PepperModuleProperty<String> prop = (PepperModuleProperty<String>) getFixture().getProperties().getProperty(TreetaggerImporterProperties.PROP_SEPARATOR_AFTER_TOKEN);
+		PepperModuleProperty<String> prop = (PepperModuleProperty<String>) getFixture().getProperties()
+				.getProperty(TreetaggerImporterProperties.PROP_SEPARATOR_AFTER_TOKEN);
 		prop.setValue("");
 
 		getFixture().mapSDocument();
@@ -286,12 +285,14 @@ public class Treetagger2SaltMapperTest {
 
 		getFixture().setDocument(SaltFactory.createSDocument());
 
-		PepperModuleProperty<String> prop = (PepperModuleProperty<String>) getFixture().getProperties().getProperty(TreetaggerImporterProperties.PROP_SEPARATOR_AFTER_TOKEN);
+		PepperModuleProperty<String> prop = (PepperModuleProperty<String>) getFixture().getProperties()
+				.getProperty(TreetaggerImporterProperties.PROP_SEPARATOR_AFTER_TOKEN);
 		prop.setValue(sep);
 
 		getFixture().mapSDocument();
 
-		assertEquals("Is" + sep + "this" + sep + "sample", getFixture().getDocument().getDocumentGraph().getTextualDSs().get(0).getText());
+		assertEquals("Is" + sep + "this" + sep + "sample",
+				getFixture().getDocument().getDocumentGraph().getTextualDSs().get(0).getText());
 	}
 
 	/**
@@ -306,7 +307,8 @@ public class Treetagger2SaltMapperTest {
 		assertEquals(tTokens.size(), sTokens.size());
 		Hashtable<SToken, String> sTokenTextTable = new Hashtable<SToken, String>();
 		for (STextualRelation sTextRel : sDocGraph.getTextualRelations()) {
-			sTokenTextTable.put(sTextRel.getSource(), sTextRel.getTarget().getText().substring(sTextRel.getStart(), sTextRel.getEnd()));
+			sTokenTextTable.put(sTextRel.getSource(),
+					sTextRel.getTarget().getText().substring(sTextRel.getStart(), sTextRel.getEnd()));
 		}
 		for (int index = 0; index < tTokens.size(); index++) {
 			Token tTok = tTokens.get(index);

--- a/src/test/java/org/corpus_tools/peppermodules/treetagger/model/impl/AnnotationTest.java
+++ b/src/test/java/org/corpus_tools/peppermodules/treetagger/model/impl/AnnotationTest.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2009 Humboldt-Universität zu Berlin, INRIA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+package org.corpus_tools.peppermodules.treetagger.model.impl;
+
+import org.corpus_tools.peppermodules.treetagger.model.Annotation;
+import org.corpus_tools.peppermodules.treetagger.model.TreetaggerFactory;
+import org.junit.Before;
+import org.junit.Test;
+
+import junit.framework.TestCase;
+
+public class AnnotationTest extends TestCase {
+
+	protected Annotation fixture = null;
+
+	@Override
+	@Before
+	protected void setUp() throws Exception {
+		fixture = TreetaggerFactory.eINSTANCE.createAnnotation();
+	}
+
+	/**
+	 * Tests equals method for annotations.
+	 */
+	@Test
+	public void testEquals() {
+		Annotation anno1 = null;
+		Annotation anno2 = null;
+		assertEquals(anno1, anno2);
+
+		anno1 = TreetaggerFactory.eINSTANCE.createAnnotation();
+		assertNotSame(anno1, anno2);
+		anno2 = TreetaggerFactory.eINSTANCE.createAnnotation();
+		assertEquals(anno1, anno2);
+
+		assertNull(anno1.getName());
+		assertNull(anno2.getName());
+		anno1.setName("annotationName");
+		assertNotSame(anno1, anno2);
+		anno2.setName("annotationName");
+		assertEquals(anno1, anno2);
+
+		assertNull(anno1.getValue());
+		assertNull(anno2.getValue());
+		anno1.setValue("annotationValue");
+		assertNotSame(anno1, anno2);
+		anno2.setValue("annotationValue");
+		assertEquals(anno1, anno2);
+	}
+
+} // AnnotationTest

--- a/src/test/java/org/corpus_tools/peppermodules/treetagger/model/impl/DocumentTest.java
+++ b/src/test/java/org/corpus_tools/peppermodules/treetagger/model/impl/DocumentTest.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2009 Humboldt-Universität zu Berlin, INRIA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+package org.corpus_tools.peppermodules.treetagger.model.impl;
+
+import static org.junit.Assert.assertEquals;
+
+import org.corpus_tools.peppermodules.treetagger.model.Annotation;
+import org.corpus_tools.peppermodules.treetagger.model.Document;
+import org.corpus_tools.peppermodules.treetagger.model.Token;
+import org.corpus_tools.peppermodules.treetagger.model.TreetaggerFactory;
+import org.junit.Test;
+
+public class DocumentTest {
+
+	/**
+	 * Tests equals method for Documents. The name field is not subject to
+	 * equality.
+	 */
+	@Test
+	public void testEquals() {
+		Document document1 = TreetaggerFactory.eINSTANCE.createDocument();
+		Document document2 = TreetaggerFactory.eINSTANCE.createDocument();
+		assertEquals(document1, document2);
+
+		Document[] docArray = { document1, document2 };
+
+		for (int docIndex = 0; docIndex < 2; docIndex++) {
+			// add some tokens to document and some annotations to tokens
+			for (int i = 0; i < 10; i++) {
+				Token token = TreetaggerFactory.eINSTANCE.createToken();
+				token.setText(String.format("token#%d.Text", i));
+				token.setDocument(docArray[docIndex]);
+				for (int j = 0; j < 2; j++) {
+					Annotation annotation = TreetaggerFactory.eINSTANCE.createAnnotation();
+					annotation.setValue(String.format("token#%d.Annotation#%d", i, j));
+					annotation.setAnnotatableElement(token);
+				}
+			}
+		}
+
+		assertEquals(document1, document2);
+	}
+
+} // DocumentTest

--- a/src/test/java/org/corpus_tools/peppermodules/treetagger/model/impl/SpanTest.java
+++ b/src/test/java/org/corpus_tools/peppermodules/treetagger/model/impl/SpanTest.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2009 Humboldt-Universität zu Berlin, INRIA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+package org.corpus_tools.peppermodules.treetagger.model.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+
+import org.corpus_tools.peppermodules.treetagger.model.Span;
+import org.corpus_tools.peppermodules.treetagger.model.TreetaggerFactory;
+import org.junit.Test;
+
+public class SpanTest {
+	/**
+	 * Tests equals method for Span.
+	 */
+	@Test
+	public void testEquals() {
+		Span span1 = null;
+		Span span2 = null;
+		assertEquals(span1, span2);
+
+		span1 = TreetaggerFactory.eINSTANCE.createSpan();
+		assertNotSame(span1, span2);
+		span2 = TreetaggerFactory.eINSTANCE.createSpan();
+		assertEquals(span1, span2);
+
+		assertNull(span1.getName());
+		assertNull(span2.getName());
+		span1.setName("spanName");
+		assertNotSame(span1, span2);
+		span2.setName("spanName");
+		assertEquals(span1, span2);
+	}
+
+} // SpanTest

--- a/src/test/java/org/corpus_tools/peppermodules/treetagger/model/impl/TokenTest.java
+++ b/src/test/java/org/corpus_tools/peppermodules/treetagger/model/impl/TokenTest.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright 2009 Humboldt-Universität zu Berlin, INRIA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+package org.corpus_tools.peppermodules.treetagger.model.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+
+import org.corpus_tools.peppermodules.treetagger.model.LemmaAnnotation;
+import org.corpus_tools.peppermodules.treetagger.model.POSAnnotation;
+import org.corpus_tools.peppermodules.treetagger.model.Token;
+import org.corpus_tools.peppermodules.treetagger.model.TreetaggerFactory;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TokenTest {
+	private Token fixture;
+
+	@Before
+	public void beforeEach() {
+		fixture = TreetaggerFactory.eINSTANCE.createToken();
+	}
+
+	@Test
+	public void testGetPosAnnotation() {
+		assertNull(fixture.getPosAnnotation());
+		POSAnnotation anno = TreetaggerFactory.eINSTANCE.createPOSAnnotation();
+		anno.setName("pos");
+		anno.setValue("VVFIN");
+		fixture.setPosAnnotation(anno);
+		assertEquals(anno, fixture.getPosAnnotation());
+	}
+
+	@Test
+	public void testGetLemmaAnnotation() {
+		assertNull(fixture.getLemmaAnnotation());
+		LemmaAnnotation anno = TreetaggerFactory.eINSTANCE.createLemmaAnnotation();
+		anno.setName("lemma");
+		anno.setValue("someLemma");
+		fixture.setLemmaAnnotation(anno);
+		assertEquals(anno, fixture.getLemmaAnnotation());
+	}
+
+	@Test
+	public void testSetLemmaAnnotation() {
+		this.testGetLemmaAnnotation();
+	}
+
+	@Test
+	public void testEquals() {
+		Token token1 = null;
+		Token token2 = null;
+		assertEquals(token1, token2);
+
+		token1 = TreetaggerFactory.eINSTANCE.createToken();
+		assertNotSame(token1, token2);
+		token2 = TreetaggerFactory.eINSTANCE.createToken();
+		assertEquals(token1, token2);
+
+		assertNull(token1.getText());
+		assertNull(token2.getText());
+		token1.setText("tokenText");
+		assertNotSame(token1, token2);
+		token2.setText("tokenText");
+		assertEquals(token1, token2);
+	}
+}

--- a/src/test/java/org/corpus_tools/peppermodules/treetagger/model/resources/XMLUtilsTests.java
+++ b/src/test/java/org/corpus_tools/peppermodules/treetagger/model/resources/XMLUtilsTests.java
@@ -1,0 +1,197 @@
+/**
+ * Copyright 2009 Humboldt-Universität zu Berlin, INRIA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+package org.corpus_tools.peppermodules.treetagger.model.resources;
+
+import java.util.AbstractMap.SimpleEntry;
+import java.util.ArrayList;
+import java.util.Hashtable;
+import java.util.Map.Entry;
+
+import org.corpus_tools.peppermodules.treetagger.model.resources.XMLUtils;
+
+import junit.framework.TestCase;
+
+/**
+ * Test case for the XMLUtils
+ * @author hildebax
+ *
+ */
+public class XMLUtilsTests extends TestCase {
+
+	public XMLUtilsTests(String name) {
+		super(name);
+	}
+
+	/**
+	 * tests whether expressions are correctly recognised as <a href="http://www.w3.org/TR/2008/REC-xml-20081126/#sec-starttags">start tag expressions</a>
+	 */
+	public final void testIsStartTag() {
+		String[] valids = {
+				"<Test>",
+				"<TAG test=''>",
+				"<TAG test='testVal'>",
+				"<TAG test='test:test'>",
+				"<TAG test=\"test\">",
+		};
+		
+		String[] invalids = {
+				"<>",
+				"<TAG test='test\">",
+				"<TAG test=\"test'>",
+				"</TAG test='testVal'>",
+				"TAG test='testVal'"
+				
+		};
+		
+		for (String valid:valids) {
+			if (!XMLUtils.isStartTag(valid)) {
+				fail();
+			}
+		};
+		
+		for (String invalid:invalids) {
+			if(XMLUtils.isStartTag(invalid)) {
+				fail();
+			}
+		};
+
+	}
+
+	/**
+	 * tests whether expressions are correctly recognised as <a href="http://www.w3.org/TR/2008/REC-xml-20081126/#NT-S">white space expression</a>
+	 */
+	public final void testIsWhiteSpace() {
+		Character x09 = new Character((char)0x09);
+		Character x0A = new Character((char)0x0A);
+		Character x0D = new Character((char)0x0D);
+		Character x20 = new Character((char)0x20);
+		
+		String[] valids = {
+				x09.toString(),
+				x0A.toString(),
+				x0D.toString(),
+				x20.toString(),
+				String.format("%c%c", x09, x0A),
+				String.format("%c%c", x20, x09),
+				String.format("%c%c", x0D, x20),
+				String.format("%c%c%c%c", x09, x20, x09, x0A),
+				String.format("%c%c%c%c", x0A, x0D, x20, x09),
+				String.format("%c%c%c%c", x09, x09, x0D, x20)
+		};
+		
+		String[] invalids = {
+				"",
+				"a",
+				"_",
+				"ten",
+				".",
+				"?"
+		};
+		
+		for (String valid:valids) {
+			if (!XMLUtils.isWhiteSpace(valid)) {
+				fail();
+			}
+		};
+		
+		for (String invalid:invalids) {
+			if(XMLUtils.isWhiteSpace(invalid)) {
+				fail();
+			}
+		};
+	}
+
+	
+	
+	/**
+	 * tests whether expressions are correctly recognised as <a href="http://www.w3.org/TR/2008/REC-xml-20081126/#NT-Eq">eq expressions</a> 
+	 */
+	public final void testIsEq() {
+		Character x09 = new Character((char)0x09);
+		Character x0A = new Character((char)0x0A);
+		Character x0D = new Character((char)0x0D);
+		Character x20 = new Character((char)0x20);
+
+		String[] valids = {
+				"=",
+				String.format("%c%c=", x09, x0A),
+				String.format("%c=%c", x20, x09),
+				String.format("=%c%c", x0D, x20),
+				String.format("%c=%c%c%c", x09, x20, x09, x0A),
+				String.format("%c%c%c=%c", x0A, x0D, x20, x09),
+				String.format("=%c%c%c%c", x09, x09, x0D, x20)
+		};
+		
+		String[] invalids = {
+				" ",
+				" ",
+				"_",
+				"t",
+				".",
+				"?"
+		};
+		
+		for (String valid:valids) {
+			if (!XMLUtils.isEq(valid)) {
+				fail();
+			}
+		};
+		
+		for (String invalid:invalids) {
+			if(XMLUtils.isEq(invalid)) {
+				fail();
+			}
+		};
+	}
+	
+	
+	/**
+	 * tests whether names are correctly extracted and returned from start tags 
+	 */
+	public final void testGetName() {
+		assertEquals("TAG", XMLUtils.getName("<TAG>"));
+		assertEquals("TAG", XMLUtils.getName("<TAG >"));
+		assertEquals("TAG", XMLUtils.getName("<TAG att='test'>"));
+	
+		assertNotSame("TAG", XMLUtils.getName("TAG att='test'>"));
+	}
+
+	/**
+	 * tests whether lists of attribute-value-pairs (implemented as <a href="http://download.oracle.com/javase/6/docs/api/java/util/1AbstractMap.SimpleEntry.html">SimpleEntry</a> (String,String) of start tags are returned correctly.
+	 */
+	public final void testGetAttributeValueList() {
+		ArrayList<SimpleEntry<String, String>> list = XMLUtils.getAttributeValueList("<TAG test='testVal' test2='test2Val' test3=\"test3Val\"    test4='test4Val'");
+		for (int i=0;i<list.size();i++) {
+			SimpleEntry<String,String> entry = list.get(i);
+			System.out.println(entry.getKey() + "\t" + entry.getValue());
+		}
+	}
+
+	/**
+	 * tests whether hashtables (String,String) of attribute-value-pairs of start tags are returned correctly.
+	 */
+	public final void testGetAttributeValueTable() {
+		Hashtable<String, String> table = XMLUtils.getAttributeValueTable("<TAG test='testVal' test2='test2Val' test3=\"test3Val\"    test4='test4Val'");
+		for (Entry<String, String> entry : table.entrySet()) {
+  		  System.out.println(entry.getKey() + "\t" + entry.getValue());
+		}
+	}
+	
+	
+	
+}

--- a/src/test/resources/testTabResource.tab
+++ b/src/test/resources/testTabResource.tab
@@ -1,0 +1,22 @@
+<meta testDoc1='testDoc1'>
+token#0.Text	token#0.Annotation#0	token#0.Annotation#1
+<SPAN span='spanFromToken1ToToken3'>
+token#1.Text	token#1.Annotation#0	token#1.Annotation#1
+token#2.Text	token#2.Annotation#0	token#2.Annotation#1
+token#3.Text	token#3.Annotation#0	token#3.Annotation#1
+</SPAN>
+</OUTOFNOWHERESPAN>
+token#4.Text	token#4.Annotation#0	token#4.Annotation#1
+<SPAN span='spanFromToken5ToToken8'>
+<NEVERCLOSINGSPAN>
+token#5.Text	token#5.Annotation#0	token#5.Annotation#1
+<SPAN span='spanFromToken6ToToken7'>
+token#6.Text	token#6.Annotation#0	token#6.Annotation#1
+token#7.Text	token#7.Annotation#0	token#7.Annotation#1
+</SPAN>
+<NOTOKENSPAN>
+</NOTOKENSPAN>
+token#8.Text	token#8.Annotation#0	token#8.Annotation#1
+</SPAN>
+token#9.Text	token#9.Annotation#0	token#9.Annotation#1
+</meta>

--- a/src/test/resources/testTabResource_output.tab
+++ b/src/test/resources/testTabResource_output.tab
@@ -1,0 +1,18 @@
+<meta testDoc1="testDoc1">
+token#0.Text	token#0.Annotation#0	token#0.Annotation#1
+<SPAN span="spanFromToken1ToToken3">
+token#1.Text	token#1.Annotation#0	token#1.Annotation#1
+token#2.Text	token#2.Annotation#0	token#2.Annotation#1
+token#3.Text	token#3.Annotation#0	token#3.Annotation#1
+</SPAN>
+token#4.Text	token#4.Annotation#0	token#4.Annotation#1
+<SPAN span="spanFromToken5ToToken8">
+token#5.Text	token#5.Annotation#0	token#5.Annotation#1
+<SPAN span="spanFromToken6ToToken7">
+token#6.Text	token#6.Annotation#0	token#6.Annotation#1
+token#7.Text	token#7.Annotation#0	token#7.Annotation#1
+</SPAN>
+token#8.Text	token#8.Annotation#0	token#8.Annotation#1
+</SPAN>
+token#9.Text	token#9.Annotation#0	token#9.Annotation#1
+</meta>


### PR DESCRIPTION
To simplify the treetagger module and to enhance the maintainability, the EMF model is transformed to a simple pojo model and directly included in the module.
