### PR TITLE
Implemented properties to alter token and annotation values

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,10 +184,24 @@ The following table contains an overview of all usable properties to customize t
 <td align="left">String</td>
 <td align="left">optional</td>
 <td align="left">_</td>
+</tr>
+<tr class="odd">
 <td align="left">treetagger.input.column[1-9][0-9]*</td>
 <td align="left">String</td>
 <td align="left">optional</td>
 <td align="left">&quot; &quot;</td>
+</tr>
+<tr class="even">
+<td align="left">treetagger.input.replaceTokens</td>
+<td align="left">String</td>
+<td align="left">optional</td>
+<td align="left">--</td>
+<tr class="odd">
+<td align="left">treetagger.input.replacementsInAnnos</td>
+<td align="left">Boolean</td>
+<td align="left">optional</td>
+<td align="left">true</td>
+</tr>
 </tr>
 
 </tbody>
@@ -243,6 +257,22 @@ The corresponding customization properties would look like this:
 <property key="treetagger.input.column3">claws</property>
 <property key="treetagger.input.column4">tok_func</property>
 ```
+
+
+#### treetagger.input.replaceTokens
+
+Specify values to find and replace in tokens. This value is a comma separated list of mappings: "REPLACED_STRING" : "REPLACEMENT" (, "REPLACED_STRING" : "REPLACEMENT")*
+
+This property can be helpful including XML escapes in TT tokens. For example, if we have tokens like `&amp;` but we would like them to be imported as `&`, we can use:
+
+```
+<property key="treetagger.input.replaceTokens">"&amp;amp;":"&amp;"</property>
+```
+
+#### treetagger.input.replacementsInAnnos
+
+If true, make token replacement patterns apply to annotations as well. This means that a lemma like `&amp;` could be made to work in the same way as with treetagger.input.replaceTokens.
+
 
 #<a name="details_ex"/>TreetaggerExporter
 Mapping to TreeTagger format

--- a/src/main/java/org/corpus_tools/peppermodules/treetagger/mapper/Treetagger2SaltMapper.java
+++ b/src/main/java/org/corpus_tools/peppermodules/treetagger/mapper/Treetagger2SaltMapper.java
@@ -19,6 +19,7 @@ package org.corpus_tools.peppermodules.treetagger.mapper;
 
 import java.util.Hashtable;
 import java.util.List;
+import java.util.Map;
 
 import org.corpus_tools.pepper.common.DOCUMENT_STATUS;
 import org.corpus_tools.pepper.impl.PepperMapperImpl;
@@ -113,9 +114,22 @@ public class Treetagger2SaltMapper extends PepperMapperImpl implements PepperMap
 		String text = null;
 		int start = 0;
 		int end = 0;
+                Map<String, String> replMap = ((TreetaggerImporterProperties) getProperties()).getReplacementMapping();
+             
 		// for (Token tToken: tTokens) {
 		for (int tokenIndex = 0; tokenIndex < tTokens.size(); tokenIndex++) {
 			Token tToken = tTokens.get(tokenIndex);
+                        if (replMap != null){
+                            for (Map.Entry<String, String> entry : replMap.entrySet())
+                            {
+                                tToken.setText(tToken.getText().replace(entry.getKey(), entry.getValue()));
+                                if (this.getProps().getReplaceInAnnos()){
+                                    for (Annotation tAnnotation : tToken.getAnnotations()) {
+                                            tAnnotation.setValue(tAnnotation.getValue().replace(entry.getKey(), entry.getValue()));
+                                    }
+                                }
+                            }
+                        }
 			if (text == null) {
 				start = 0;
 				end = tToken.getText().length();


### PR DESCRIPTION
- treetagger.input.replaceTokens allows string find and replace in token values
- treetagger.input.replacementsInAnnos applies replacements to token annotations as well
- Allows data with XML escapes in TT format, since we can replace escaped token and annotation values with actual values
- Closes korpling/pepperModules-TreetaggerModules#8
